### PR TITLE
Add HACS default repository validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,26 @@ jobs:
 
       - name: Run Ruff
         run: uv run ruff check .
+
+  hassfest:
+    name: Hassfest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run hassfest
+        uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    name: HACS validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Run HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration
+          comment: false

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "codex_assist",
   "name": "Codex Assist",
+  "after_dependencies": ["conversation"],
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
   "requirements": ["httpx>=0.27.0"],
-  "version": "0.1.7",
-  "after_dependencies": ["conversation"]
+  "version": "0.1.7"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
   "name": "Codex Assist",
   "content_in_root": false,
-  "domains": ["codex_assist"],
   "homeassistant": "2026.5.0",
   "render_readme": true
 }


### PR DESCRIPTION
## Summary
- add Hassfest and HACS validation jobs to CI
- sort the Home Assistant manifest keys for Hassfest
- remove unsupported `domains` key from `hacs.json`

## Verification
- `uv run pytest -q`
- `uv run ruff check .`
- `docker run --rm -v "/home/laptop/ha-codex-assist":/github/workspace ghcr.io/home-assistant/hassfest`
- local `ghcr.io/hacs/action:main` validation against `prep-hacs-default-checks`