### PR TITLE
Add native AI Task image and attachment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Requirements: Home Assistant `2026.5.0` or newer, HACS, and a ChatGPT account/pl
 - Ask about exposed entity state and request simple actions in the same Assist chat.
 - Stream replies in Assist while Codex is answering.
 - Configure model, prompt, reasoning effort, reasoning summary, and text verbosity from the integration options flow.
+- On the v0.2 media branch, test native AI Task attachment handling and subscription-backed image generation with curated image quality and size controls.
 
 <p align="center">
   <img src="assets/codex-assist-light-control.png" alt="Codex Assist confirming yard lights are on and turning them off" width="430">

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Codex Assist signs in with Codex-style ChatGPT device-code auth, adds Codex as a
 
 Requirements: Home Assistant `2026.5.0` or newer, HACS, and a ChatGPT account/plan with Codex access.
 
+[![Open this repository in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=itsreverence&repository=ha-codex-assist&category=integration)
+[![Add the Codex Assist integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=codex_assist)
+
 1. In Home Assistant, open **HACS → Custom repositories**.
 2. Add this repository as an **Integration**:
 
@@ -29,10 +32,11 @@ Requirements: Home Assistant `2026.5.0` or newer, HACS, and a ChatGPT account/pl
 
 3. Install **Codex Assist**.
 4. Restart Home Assistant.
-5. Go to **Settings → Devices & services → Add integration**.
-6. Search for **Codex Assist** and complete device-code sign-in.
-7. Select **Codex Assist** in your Assist pipeline.
-8. Test with a harmless exposed entity first, like a single light.
+5. In ChatGPT, enable **Settings → Security → Enable device code authorization for Codex** if it is available on your account.
+6. Go to **Settings → Devices & services → Add integration**, or use the button above.
+7. Search for **Codex Assist** and complete device-code sign-in.
+8. Select **Codex Assist** in your Assist pipeline.
+9. Test with a harmless exposed entity first, like a single light.
 
 ## Why use it?
 

--- a/custom_components/codex_assist/__init__.py
+++ b/custom_components/codex_assist/__init__.py
@@ -12,11 +12,17 @@ DOMAIN = "codex_assist"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from homeassistant.const import Platform
 
-    await hass.config_entries.async_forward_entry_setups(entry, (Platform.CONVERSATION,))
+    await hass.config_entries.async_forward_entry_setups(
+        entry,
+        (Platform.CONVERSATION, Platform.AI_TASK),
+    )
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from homeassistant.const import Platform
 
-    return await hass.config_entries.async_unload_platforms(entry, (Platform.CONVERSATION,))
+    return await hass.config_entries.async_unload_platforms(
+        entry,
+        (Platform.CONVERSATION, Platform.AI_TASK),
+    )

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util.json import json_loads
 
 from .codex_auth import CodexAuthClient, CodexTokenSet
-from .codex_client import CodexAuthenticationError, CodexClient
+from .codex_client import CodexAuthenticationError, CodexClient, CodexImageResult
 from .codex_runtime import resolve_runtime_tokens
 from .config_flow import (
     DEFAULT_REASONING_EFFORT,
@@ -55,6 +55,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
     _attr_name = "Codex Assist AI Task"
     _attr_supported_features = (
         ai_task.AITaskEntityFeature.GENERATE_DATA
+        | ai_task.AITaskEntityFeature.GENERATE_IMAGE
         | ai_task.AITaskEntityFeature.SUPPORT_ATTACHMENTS
     )
 
@@ -131,6 +132,72 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
             data=_structured_data_from_text(text, task.structure),
         )
 
+    async def _async_generate_image(
+        self,
+        task: ai_task.GenImageTask,
+        chat_log: conversation.ChatLog,
+    ) -> ai_task.GenImageTaskResult:
+        """Generate an image from instructions and optional HA-native attachments."""
+        settings = {**self.entry.data, **self.entry.options}
+        chat_model = settings.get("model", "gpt-5.4")
+        image_model = settings.get("image_model", "gpt-image-2-medium")
+
+        http_client = get_async_client(self.hass)
+        auth_client = CodexAuthClient(http_client=http_client)
+        try:
+            tokens = await resolve_runtime_tokens(
+                self.entry.data,
+                auth_client=auth_client,
+                async_update_entry_data=lambda data: self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data=data,
+                ),
+            )
+        except RuntimeError as err:
+            LOGGER.warning("Codex Assist AI Task authentication failed: %s", err)
+            self.entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "Codex Assist needs you to sign in again. Open Home Assistant "
+                "repairs or the integration page to reauthenticate."
+            ) from err
+
+        codex = CodexClient(http_client=http_client, access_token=tokens.access_token)
+        try:
+            result = await _generate_codex_ai_task_image(
+                hass=self.hass,
+                entry=self.entry,
+                auth_client=auth_client,
+                tokens=tokens,
+                codex=codex,
+                chat_log=chat_log,
+                task=task,
+                chat_model=chat_model,
+                image_model=image_model,
+            )
+        except (httpx.HTTPError, RuntimeError) as err:
+            LOGGER.exception("Codex Assist AI Task image request failed")
+            raise HomeAssistantError(f"Codex Assist image generation failed: {err}") from err
+        except (ValueError, TypeError) as err:
+            LOGGER.exception("Codex Assist AI Task image response handling failed")
+            raise HomeAssistantError(
+                f"Codex Assist image response handling failed: {err}"
+            ) from err
+
+        chat_log.async_add_assistant_content_without_tools(
+            conversation.AssistantContent(
+                agent_id=self.entity_id,
+                content=result.revised_prompt or "",
+            )
+        )
+
+        return ai_task.GenImageTaskResult(
+            image_data=result.image_data,
+            conversation_id=chat_log.conversation_id,
+            mime_type=result.mime_type,
+            model=result.model,
+            revised_prompt=result.revised_prompt,
+        )
+
 
 async def _run_codex_ai_task_chat_log(
     *,
@@ -186,6 +253,45 @@ async def _run_codex_ai_task_chat_log(
             )
         if not chat_log.unresponded_tool_results:
             break
+
+
+async def _generate_codex_ai_task_image(
+    *,
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    auth_client: CodexAuthClient,
+    tokens: CodexTokenSet,
+    codex: CodexClient,
+    chat_log: conversation.ChatLog,
+    task: ai_task.GenImageTask,
+    chat_model: str,
+    image_model: str,
+) -> CodexImageResult:
+    """Run Codex image generation with one auth refresh retry."""
+    try:
+        return await codex.generate_image(
+            prompt=task.instructions,
+            input_items=await _codex_input_from_chat_log(hass, chat_log),
+            chat_model=chat_model,
+            image_model=image_model,
+        )
+    except CodexAuthenticationError as err:
+        LOGGER.warning(
+            "Codex Assist AI Task image access token was rejected; "
+            "refreshing and retrying once: %s",
+            err,
+        )
+        tokens = await _refresh_runtime_tokens(hass, entry, auth_client, tokens)
+        codex = CodexClient(
+            http_client=get_async_client(hass),
+            access_token=tokens.access_token,
+        )
+        return await codex.generate_image(
+            prompt=task.instructions,
+            input_items=await _codex_input_from_chat_log(hass, chat_log),
+            chat_model=chat_model,
+            image_model=image_model,
+        )
 
 
 def _structured_data_from_text(text: str, structure: dict[str, Any] | None) -> Any:

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -12,6 +12,7 @@ from homeassistant.util.json import json_loads
 
 from .codex_auth import CodexAuthClient, CodexTokenSet
 from .codex_client import CodexAuthenticationError, CodexClient, CodexImageResult
+from .codex_image import DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_SIZE
 from .codex_runtime import resolve_runtime_tokens
 from .config_flow import (
     DEFAULT_REASONING_EFFORT,
@@ -140,7 +141,8 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
         """Generate an image from instructions and optional HA-native attachments."""
         settings = {**self.entry.data, **self.entry.options}
         chat_model = settings.get("model", "gpt-5.4")
-        image_model = settings.get("image_model", "gpt-image-2-medium")
+        image_model = settings.get("image_model", DEFAULT_IMAGE_MODEL)
+        image_size = settings.get("image_size", DEFAULT_IMAGE_SIZE)
 
         http_client = get_async_client(self.hass)
         auth_client = CodexAuthClient(http_client=http_client)
@@ -173,6 +175,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
                 task=task,
                 chat_model=chat_model,
                 image_model=image_model,
+                image_size=image_size,
             )
         except (httpx.HTTPError, RuntimeError) as err:
             LOGGER.exception("Codex Assist AI Task image request failed")
@@ -266,6 +269,7 @@ async def _generate_codex_ai_task_image(
     task: ai_task.GenImageTask,
     chat_model: str,
     image_model: str,
+    image_size: str,
 ) -> CodexImageResult:
     """Run Codex image generation with one auth refresh retry."""
     try:
@@ -274,6 +278,7 @@ async def _generate_codex_ai_task_image(
             input_items=await _codex_input_from_chat_log(hass, chat_log),
             chat_model=chat_model,
             image_model=image_model,
+            size=image_size,
         )
     except CodexAuthenticationError as err:
         LOGGER.warning(
@@ -291,6 +296,7 @@ async def _generate_codex_ai_task_image(
             input_items=await _codex_input_from_chat_log(hass, chat_log),
             chat_model=chat_model,
             image_model=image_model,
+            size=image_size,
         )
 
 

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from homeassistant.components import ai_task, conversation
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.util.json import json_loads
+
+from .codex_auth import CodexAuthClient, CodexTokenSet
+from .codex_client import CodexAuthenticationError, CodexClient
+from .codex_runtime import resolve_runtime_tokens
+from .config_flow import (
+    DEFAULT_REASONING_EFFORT,
+    DEFAULT_REASONING_SUMMARY,
+    DEFAULT_TEXT_VERBOSITY,
+)
+from .conversation import (
+    MAX_TOOL_ITERATIONS,
+    _codex_input_from_chat_log,
+    _codex_tools_from_chat_log,
+    _instructions_from_chat_log,
+    _refresh_runtime_tokens,
+    _stream_codex_turn_into_chat_log,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    async_add_entities([CodexAssistAITaskEntity(entry)])
+
+
+class CodexAssistAITaskEntity(ai_task.AITaskEntity):
+    """AI Task entity for Codex Assist.
+
+    Home Assistant AI Task explicitly supports attachment inputs through the
+    SUPPORT_ATTACHMENTS feature flag. Normal Assist conversation surfaces may
+    carry chat-log attachments internally, but they do not expose an equivalent
+    conversation feature flag or process-service attachment schema.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Codex Assist AI Task"
+    _attr_supported_features = (
+        ai_task.AITaskEntityFeature.GENERATE_DATA
+        | ai_task.AITaskEntityFeature.SUPPORT_ATTACHMENTS
+    )
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        self.entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_ai_task"
+
+    async def _async_generate_data(
+        self,
+        task: ai_task.GenDataTask,
+        chat_log: conversation.ChatLog,
+    ) -> ai_task.GenDataTaskResult:
+        """Generate data from instructions and optional HA-native attachments."""
+        settings = {**self.entry.data, **self.entry.options}
+        model = settings.get("model", "gpt-5.4")
+        prompt = settings.get(
+            "prompt",
+            "You are a concise Home Assistant AI Task agent.",
+        )
+        reasoning_effort = settings.get("reasoning_effort", DEFAULT_REASONING_EFFORT)
+        reasoning_summary = settings.get("reasoning_summary", DEFAULT_REASONING_SUMMARY)
+        text_verbosity = settings.get("text_verbosity", DEFAULT_TEXT_VERBOSITY)
+
+        http_client = get_async_client(self.hass)
+        auth_client = CodexAuthClient(http_client=http_client)
+        try:
+            tokens = await resolve_runtime_tokens(
+                self.entry.data,
+                auth_client=auth_client,
+                async_update_entry_data=lambda data: self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data=data,
+                ),
+            )
+        except RuntimeError as err:
+            LOGGER.warning("Codex Assist AI Task authentication failed: %s", err)
+            self.entry.async_start_reauth(self.hass)
+            raise HomeAssistantError(
+                "Codex Assist needs you to sign in again. Open Home Assistant "
+                "repairs or the integration page to reauthenticate."
+            ) from err
+
+        codex = CodexClient(http_client=http_client, access_token=tokens.access_token)
+        try:
+            await _run_codex_ai_task_chat_log(
+                hass=self.hass,
+                entry=self.entry,
+                auth_client=auth_client,
+                tokens=tokens,
+                codex=codex,
+                chat_log=chat_log,
+                entity_id=self.entity_id or "",
+                model=model,
+                prompt=prompt,
+                reasoning_effort=reasoning_effort,
+                reasoning_summary=reasoning_summary,
+                text_verbosity=text_verbosity,
+            )
+        except (httpx.HTTPError, RuntimeError) as err:
+            LOGGER.exception("Codex Assist AI Task model request failed")
+            raise HomeAssistantError(f"Codex Assist AI Task failed: {err}") from err
+        except (ValueError, TypeError) as err:
+            LOGGER.exception("Codex Assist AI Task response handling failed")
+            raise HomeAssistantError(
+                f"Codex Assist AI Task response handling failed: {err}"
+            ) from err
+
+        if not isinstance(chat_log.content[-1], conversation.AssistantContent):
+            raise HomeAssistantError("Codex Assist AI Task did not produce a response")
+
+        text = chat_log.content[-1].content or ""
+        return ai_task.GenDataTaskResult(
+            conversation_id=chat_log.conversation_id,
+            data=_structured_data_from_text(text, task.structure),
+        )
+
+
+async def _run_codex_ai_task_chat_log(
+    *,
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    auth_client: CodexAuthClient,
+    tokens: CodexTokenSet,
+    codex: CodexClient,
+    chat_log: conversation.ChatLog,
+    entity_id: str,
+    model: str,
+    prompt: str,
+    reasoning_effort: str,
+    reasoning_summary: str,
+    text_verbosity: str,
+) -> None:
+    """Run Codex over an AI Task chat log with one auth refresh retry."""
+    for _iteration in range(MAX_TOOL_ITERATIONS):
+        try:
+            await _stream_codex_turn_into_chat_log(
+                chat_log=chat_log,
+                codex=codex,
+                entity_id=entity_id,
+                model=model,
+                instructions=_instructions_from_chat_log(chat_log, prompt),
+                input_items=await _codex_input_from_chat_log(hass, chat_log),
+                tools=_codex_tools_from_chat_log(chat_log),
+                reasoning_effort=reasoning_effort,
+                reasoning_summary=reasoning_summary,
+                text_verbosity=text_verbosity,
+            )
+        except CodexAuthenticationError as err:
+            LOGGER.warning(
+                "Codex Assist AI Task access token was rejected; refreshing and retrying once: %s",
+                err,
+            )
+            tokens = await _refresh_runtime_tokens(hass, entry, auth_client, tokens)
+            codex = CodexClient(
+                http_client=get_async_client(hass),
+                access_token=tokens.access_token,
+            )
+            await _stream_codex_turn_into_chat_log(
+                chat_log=chat_log,
+                codex=codex,
+                entity_id=entity_id,
+                model=model,
+                instructions=_instructions_from_chat_log(chat_log, prompt),
+                input_items=await _codex_input_from_chat_log(hass, chat_log),
+                tools=_codex_tools_from_chat_log(chat_log),
+                reasoning_effort=reasoning_effort,
+                reasoning_summary=reasoning_summary,
+                text_verbosity=text_verbosity,
+            )
+        if not chat_log.unresponded_tool_results:
+            break
+
+
+def _structured_data_from_text(text: str, structure: dict[str, Any] | None) -> Any:
+    """Return plain text or parsed JSON for structured AI Task requests."""
+    if not structure:
+        return text
+    try:
+        return json_loads(text)
+    except ValueError as err:
+        LOGGER.error("Failed to parse Codex Assist AI Task JSON response: %s", text)
+        raise HomeAssistantError("Codex Assist AI Task returned invalid JSON") from err

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -12,7 +12,7 @@ from homeassistant.util.json import json_loads
 
 from .codex_auth import CodexAuthClient, CodexTokenSet
 from .codex_client import CodexAuthenticationError, CodexClient, CodexImageResult
-from .codex_image import DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_SIZE
+from .codex_image import DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_SIZE, image_size_dimensions
 from .codex_runtime import resolve_runtime_tokens
 from .config_flow import (
     DEFAULT_REASONING_EFFORT,
@@ -193,10 +193,13 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
             )
         )
 
+        width, height = image_size_dimensions(image_size)
         return ai_task.GenImageTaskResult(
             image_data=result.image_data,
             conversation_id=chat_log.conversation_id,
             mime_type=result.mime_type,
+            width=width,
+            height=height,
             model=result.model,
             revised_prompt=result.revised_prompt,
         )

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -6,6 +6,8 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+from .codex_image import image_model_quality, validate_image_size
+
 CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex"
 
 
@@ -294,7 +296,8 @@ def _image_generation_payload(
     image_model: str,
     size: str,
 ) -> dict[str, Any]:
-    quality = _image_model_quality(image_model)
+    quality = image_model_quality(image_model)
+    size = validate_image_size(size)
     return {
         "model": chat_model,
         "store": False,
@@ -329,13 +332,6 @@ def _image_generation_payload(
         "stream": True,
     }
 
-
-def _image_model_quality(image_model: str) -> str:
-    return {
-        "gpt-image-2-low": "low",
-        "gpt-image-2-medium": "medium",
-        "gpt-image-2-high": "high",
-    }.get(image_model, "medium")
 
 
 def _extract_image_b64(value: Any) -> str | None:

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -18,7 +18,7 @@ class AsyncPostClient(Protocol):
 @dataclass(frozen=True)
 class CodexMessage:
     role: str
-    content: str
+    content: str | list[dict[str, Any]]
 
 
 @dataclass(frozen=True)
@@ -224,6 +224,33 @@ def _supports_reasoning_options(model: str) -> bool:
 
 def codex_messages_to_input_items(messages: list[CodexMessage]) -> list[dict[str, Any]]:
     return [{"role": message.role, "content": message.content} for message in messages]
+
+
+def codex_user_content_with_images(
+    text: str,
+    images: list[tuple[str, bytes]],
+) -> str | list[dict[str, Any]]:
+    """Build a Codex user content payload with HA-native image attachments.
+
+    The Responses API expects multimodal user content as an ordered list with
+    input_text followed by one input_image item per image. PDFs and other file
+    types are intentionally not handled here; add them only when the integration
+    explicitly supports those HA attachment MIME types.
+    """
+    if not images:
+        return text
+
+    content: list[dict[str, Any]] = [{"type": "input_text", "text": text}]
+    for mime_type, data in images:
+        encoded = base64.b64encode(data).decode("ascii")
+        content.append(
+            {
+                "type": "input_image",
+                "image_url": f"data:{mime_type};base64,{encoded}",
+                "detail": "auto",
+            }
+        )
+    return content
 
 
 def codex_headers(access_token: str) -> dict[str, str]:

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -35,6 +35,14 @@ class CodexTurnResult:
 
 
 @dataclass(frozen=True)
+class CodexImageResult:
+    image_data: bytes
+    mime_type: str
+    model: str
+    revised_prompt: str | None = None
+
+
+@dataclass(frozen=True)
 class CodexTextDelta:
     text: str
 
@@ -187,6 +195,66 @@ class CodexClient:
                 if delta is not None:
                     yield delta
 
+    async def generate_image(
+        self,
+        *,
+        prompt: str,
+        input_items: list[dict[str, Any]] | None = None,
+        chat_model: str = "gpt-5.4",
+        image_model: str = "gpt-image-2-medium",
+        size: str = "1024x1024",
+    ) -> CodexImageResult:
+        """Generate an image through Codex Responses image_generation tool."""
+        payload = _image_generation_payload(
+            prompt=prompt,
+            input_items=input_items,
+            chat_model=chat_model,
+            image_model=image_model,
+            size=size,
+        )
+
+        image_b64: str | None = None
+        text_parts: list[str] = []
+        async with self._http_client.stream(
+            "POST",
+            f"{self._base_url}/responses",
+            headers=codex_headers(self._access_token),
+            json=payload,
+            timeout=300,
+        ) as response:
+            if response.status_code != 200:
+                error = await _stream_response_error(response)
+                if response.status_code == 401 or error.code == "token_invalidated":
+                    raise CodexAuthenticationError(
+                        f"Codex authentication failed: {error.detail}"
+                    )
+                raise RuntimeError(
+                    f"Codex image request failed with status {response.status_code}: {error.detail}"
+                )
+
+            async for event in _aiter_sse_events(response):
+                found = _extract_image_b64(event)
+                if found:
+                    image_b64 = found
+                delta = _stream_delta_from_event(event)
+                if isinstance(delta, CodexTextDelta):
+                    text_parts.append(delta.text)
+
+        if not image_b64:
+            raise RuntimeError("Codex response contained no image_generation result")
+
+        try:
+            image_data = base64.b64decode(image_b64, validate=True)
+        except (ValueError, TypeError) as err:
+            raise RuntimeError("Codex image_generation result was not valid base64") from err
+
+        return CodexImageResult(
+            image_data=image_data,
+            mime_type="image/png",
+            model=image_model,
+            revised_prompt="".join(text_parts).strip() or None,
+        )
+
 
 def _responses_payload(
     *,
@@ -216,6 +284,81 @@ def _responses_payload(
         if text_verbosity:
             payload["text"] = {"verbosity": text_verbosity}
     return payload
+
+
+def _image_generation_payload(
+    *,
+    prompt: str,
+    input_items: list[dict[str, Any]] | None,
+    chat_model: str,
+    image_model: str,
+    size: str,
+) -> dict[str, Any]:
+    quality = _image_model_quality(image_model)
+    return {
+        "model": chat_model,
+        "store": False,
+        "instructions": (
+            "You are an assistant that must fulfill image generation requests "
+            "by using the image_generation tool when provided."
+        ),
+        "input": input_items
+        or [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+            }
+        ],
+        "tools": [
+            {
+                "type": "image_generation",
+                "model": "gpt-image-2",
+                "size": size,
+                "quality": quality,
+                "output_format": "png",
+                "background": "opaque",
+                "partial_images": 1,
+            }
+        ],
+        "tool_choice": {
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "image_generation"}],
+        },
+        "stream": True,
+    }
+
+
+def _image_model_quality(image_model: str) -> str:
+    return {
+        "gpt-image-2-low": "low",
+        "gpt-image-2-medium": "medium",
+        "gpt-image-2-high": "high",
+    }.get(image_model, "medium")
+
+
+def _extract_image_b64(value: Any) -> str | None:
+    """Return the newest image b64 embedded in a Responses event payload."""
+    found: str | None = None
+    if isinstance(value, dict):
+        if value.get("type") == "image_generation_call":
+            result = value.get("result")
+            if isinstance(result, str) and result:
+                found = result
+        partial = value.get("partial_image_b64")
+        if isinstance(partial, str) and partial:
+            found = partial
+        for child in value.values():
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    elif isinstance(value, list):
+        for child in value:
+            nested = _extract_image_b64(child)
+            if nested:
+                found = nested
+    return found
 
 
 def _supports_reasoning_options(model: str) -> bool:
@@ -350,11 +493,16 @@ def extract_streamed_turn_result(stream_text: str) -> CodexTurnResult:
 
 
 def _iter_sse_events(stream_text: str):
+    event_name: str | None = None
     data_lines: list[str] = []
 
     def flush_event():
+        nonlocal event_name
         if not data_lines:
+            event_name = None
             return None
+        event = event_name
+        event_name = None
         data = "\n".join(data_lines)
         data_lines.clear()
         if data == "[DONE]":
@@ -363,6 +511,8 @@ def _iter_sse_events(stream_text: str):
             payload = json.loads(data)
         except json.JSONDecodeError:
             return None
+        if isinstance(payload, dict) and event and "type" not in payload:
+            payload["type"] = event
         return payload if isinstance(payload, dict) else None
 
     for line in stream_text.splitlines():
@@ -373,6 +523,8 @@ def _iter_sse_events(stream_text: str):
             continue
         if line.startswith("data:"):
             data_lines.append(line.removeprefix("data:").strip())
+        elif line.startswith("event:"):
+            event_name = line.removeprefix("event:").strip()
 
     payload = flush_event()
     if payload is not None:
@@ -454,24 +606,30 @@ def _tool_call_from_item(item: dict[str, Any], arguments: str) -> CodexToolCall:
 
 
 async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:
+    event_name: str | None = None
     data_lines: list[str] = []
 
     async for line in response.aiter_lines():
         if not line.strip():
-            payload = _parse_sse_payload(data_lines)
+            payload = _parse_sse_payload(data_lines, event_name)
+            event_name = None
             data_lines.clear()
             if payload is not None:
                 yield payload
             continue
         if line.startswith("data:"):
             data_lines.append(line.removeprefix("data:").strip())
+        elif line.startswith("event:"):
+            event_name = line.removeprefix("event:").strip()
 
-    payload = _parse_sse_payload(data_lines)
+    payload = _parse_sse_payload(data_lines, event_name)
     if payload is not None:
         yield payload
 
 
-def _parse_sse_payload(data_lines: list[str]) -> dict[str, Any] | None:
+def _parse_sse_payload(
+    data_lines: list[str], event_name: str | None = None
+) -> dict[str, Any] | None:
     if not data_lines:
         return None
     data = "\n".join(data_lines)
@@ -481,6 +639,8 @@ def _parse_sse_payload(data_lines: list[str]) -> dict[str, Any] | None:
         payload = json.loads(data)
     except json.JSONDecodeError:
         return None
+    if isinstance(payload, dict) and event_name and "type" not in payload:
+        payload["type"] = event_name
     return payload if isinstance(payload, dict) else None
 
 

--- a/custom_components/codex_assist/codex_image.py
+++ b/custom_components/codex_assist/codex_image.py
@@ -27,3 +27,10 @@ def validate_image_size(size: str) -> str:
     if size not in IMAGE_SIZE_OPTIONS:
         raise ValueError(f"Unsupported Codex Assist image size: {size}")
     return size
+
+
+def image_size_dimensions(size: str) -> tuple[int, int]:
+    """Return width and height for a supported OpenAI image-generation size."""
+    size = validate_image_size(size)
+    width, height = size.split("x", maxsplit=1)
+    return int(width), int(height)

--- a/custom_components/codex_assist/codex_image.py
+++ b/custom_components/codex_assist/codex_image.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+DEFAULT_IMAGE_MODEL = "gpt-image-2-medium"
+DEFAULT_IMAGE_SIZE = "1024x1024"
+IMAGE_MODEL_QUALITY = {
+    "gpt-image-2-low": "low",
+    "gpt-image-2-medium": "medium",
+    "gpt-image-2-high": "high",
+}
+IMAGE_SIZE_OPTIONS = [
+    "1024x1024",
+    "1536x1024",
+    "1024x1536",
+]
+
+
+def image_model_quality(image_model: str) -> str:
+    """Return the supported OpenAI image-generation quality for an image option."""
+    try:
+        return IMAGE_MODEL_QUALITY[image_model]
+    except KeyError as err:
+        raise ValueError(f"Unsupported Codex Assist image model: {image_model}") from err
+
+
+def validate_image_size(size: str) -> str:
+    """Return a supported OpenAI image-generation size or raise."""
+    if size not in IMAGE_SIZE_OPTIONS:
+        raise ValueError(f"Unsupported Codex Assist image size: {size}")
+    return size

--- a/custom_components/codex_assist/config_flow.py
+++ b/custom_components/codex_assist/config_flow.py
@@ -14,12 +14,20 @@ from .codex_auth import (
     CodexAuthClient,
     CodexDeviceCode,
 )
+from .codex_image import (
+    DEFAULT_IMAGE_MODEL,
+    DEFAULT_IMAGE_SIZE,
+    IMAGE_MODEL_QUALITY,
+    IMAGE_SIZE_OPTIONS,
+)
 from .codex_models import DEFAULT_CODEX_MODELS, fetch_codex_model_ids
 
 CONF_ACCESS_TOKEN = "access_token"
 CONF_PROMPT = "prompt"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_MODEL = "model"
+CONF_IMAGE_MODEL = "image_model"
+CONF_IMAGE_SIZE = "image_size"
 CONF_REASONING_EFFORT = "reasoning_effort"
 CONF_REASONING_SUMMARY = "reasoning_summary"
 CONF_TEXT_VERBOSITY = "text_verbosity"
@@ -101,6 +109,8 @@ class CodexAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             key: entry_data[key]
             for key in (
                 CONF_MODEL,
+                CONF_IMAGE_MODEL,
+                CONF_IMAGE_SIZE,
                 CONF_PROMPT,
                 CONF_REASONING_EFFORT,
                 CONF_REASONING_SUMMARY,
@@ -164,12 +174,28 @@ def _settings_schema(
     *,
     model_options: list[str],
 ) -> vol.Schema:
+    model_options = list(dict.fromkeys([*model_options, DEFAULT_MODEL]))
     model_default = defaults.get(CONF_MODEL, DEFAULT_MODEL)
-    model_options = list(dict.fromkeys([*model_options, str(model_default), DEFAULT_MODEL]))
+    if model_default not in model_options:
+        model_default = DEFAULT_MODEL
+    image_model_default = defaults.get(CONF_IMAGE_MODEL, DEFAULT_IMAGE_MODEL)
+    if image_model_default not in IMAGE_MODEL_QUALITY:
+        image_model_default = DEFAULT_IMAGE_MODEL
+    image_size_default = defaults.get(CONF_IMAGE_SIZE, DEFAULT_IMAGE_SIZE)
+    if image_size_default not in IMAGE_SIZE_OPTIONS:
+        image_size_default = DEFAULT_IMAGE_SIZE
 
     return vol.Schema(
         {
             vol.Optional(CONF_MODEL, default=model_default): _model_selector(model_options),
+            vol.Optional(
+                CONF_IMAGE_MODEL,
+                default=image_model_default,
+            ): _image_model_selector(),
+            vol.Optional(
+                CONF_IMAGE_SIZE,
+                default=image_size_default,
+            ): _image_size_selector(),
             vol.Optional(
                 CONF_PROMPT,
                 default=defaults.get(CONF_PROMPT, DEFAULT_PROMPT),
@@ -212,6 +238,31 @@ def _model_selector(model_options: list[str]) -> selector.SelectSelector:
                 selector.SelectOptionDict(value=model, label=model) for model in model_options
             ],
             mode=selector.SelectSelectorMode.DROPDOWN,
-            custom_value=True,
+        )
+    )
+
+
+def _image_model_selector() -> selector.SelectSelector:
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[
+                selector.SelectOptionDict(value="gpt-image-2-low", label="Low"),
+                selector.SelectOptionDict(value="gpt-image-2-medium", label="Medium"),
+                selector.SelectOptionDict(value="gpt-image-2-high", label="High"),
+            ],
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
+
+
+def _image_size_selector() -> selector.SelectSelector:
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[
+                selector.SelectOptionDict(value="1024x1024", label="Square (1024×1024)"),
+                selector.SelectOptionDict(value="1536x1024", label="Landscape (1536×1024)"),
+                selector.SelectOptionDict(value="1024x1536", label="Portrait (1024×1536)"),
+            ],
+            mode=selector.SelectSelectorMode.DROPDOWN,
         )
     )

--- a/custom_components/codex_assist/config_flow.py
+++ b/custom_components/codex_assist/config_flow.py
@@ -189,14 +189,6 @@ def _settings_schema(
         {
             vol.Optional(CONF_MODEL, default=model_default): _model_selector(model_options),
             vol.Optional(
-                CONF_IMAGE_MODEL,
-                default=image_model_default,
-            ): _image_model_selector(),
-            vol.Optional(
-                CONF_IMAGE_SIZE,
-                default=image_size_default,
-            ): _image_size_selector(),
-            vol.Optional(
                 CONF_PROMPT,
                 default=defaults.get(CONF_PROMPT, DEFAULT_PROMPT),
             ): str,
@@ -227,6 +219,14 @@ def _settings_schema(
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
+            vol.Optional(
+                CONF_IMAGE_MODEL,
+                default=image_model_default,
+            ): _image_model_selector(),
+            vol.Optional(
+                CONF_IMAGE_SIZE,
+                default=image_size_default,
+            ): _image_size_selector(),
         }
     )
 

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -23,6 +23,7 @@ from .codex_client import (
     CodexStreamDelta,
     CodexTextDelta,
     CodexToolCallDelta,
+    codex_user_content_with_images,
 )
 from .codex_runtime import resolve_runtime_tokens
 from .config_flow import (
@@ -32,6 +33,7 @@ from .config_flow import (
 )
 
 MAX_TOOL_ITERATIONS = 5
+MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
 
 
@@ -119,7 +121,7 @@ class CodexAssistConversationEntity(
                         entity_id=self.entity_id or "",
                         model=model,
                         instructions=_instructions_from_chat_log(chat_log, prompt),
-                        input_items=_codex_input_from_chat_log(chat_log),
+                        input_items=await _codex_input_from_chat_log(self.hass, chat_log),
                         tools=_codex_tools_from_chat_log(chat_log),
                         reasoning_effort=reasoning_effort,
                         reasoning_summary=reasoning_summary,
@@ -159,7 +161,7 @@ class CodexAssistConversationEntity(
                             entity_id=self.entity_id or "",
                             model=model,
                             instructions=_instructions_from_chat_log(chat_log, prompt),
-                            input_items=_codex_input_from_chat_log(chat_log),
+                            input_items=await _codex_input_from_chat_log(self.hass, chat_log),
                             tools=_codex_tools_from_chat_log(chat_log),
                             reasoning_effort=reasoning_effort,
                             reasoning_summary=reasoning_summary,
@@ -299,7 +301,10 @@ def _instructions_from_chat_log(
     return fallback_prompt
 
 
-def _codex_input_from_chat_log(chat_log: conversation.ChatLog) -> list[dict[str, Any]]:
+async def _codex_input_from_chat_log(
+    hass: HomeAssistant,
+    chat_log: conversation.ChatLog,
+) -> list[dict[str, Any]]:
     input_items: list[dict[str, Any]] = []
     for content in chat_log.content:
         role = getattr(content, "role", None)
@@ -316,7 +321,14 @@ def _codex_input_from_chat_log(chat_log: conversation.ChatLog) -> list[dict[str,
             )
             continue
         if role in {"user", "assistant"} and isinstance(text, str) and text.strip():
-            input_items.append({"role": role, "content": text})
+            item_content: str | list[dict[str, Any]] = text
+            if role == "user":
+                images = await _async_image_attachments_for_codex(
+                    hass,
+                    getattr(content, "attachments", None),
+                )
+                item_content = codex_user_content_with_images(text, images)
+            input_items.append({"role": role, "content": item_content})
 
         tool_calls = getattr(content, "tool_calls", None)
         if role == "assistant" and tool_calls:
@@ -331,6 +343,38 @@ def _codex_input_from_chat_log(chat_log: conversation.ChatLog) -> list[dict[str,
                 )
 
     return input_items[-24:]
+
+
+async def _async_image_attachments_for_codex(
+    hass: HomeAssistant,
+    attachments: Any,
+) -> list[tuple[str, bytes]]:
+    if not attachments:
+        return []
+    return await hass.async_add_executor_job(_image_attachments_for_codex, attachments)
+
+
+def _image_attachments_for_codex(attachments: Any) -> list[tuple[str, bytes]]:
+    images: list[tuple[str, bytes]] = []
+    for attachment in attachments:
+        mime_type = getattr(attachment, "mime_type", "")
+        if not isinstance(mime_type, str) or not mime_type.startswith("image/"):
+            continue
+        path = getattr(attachment, "path", None)
+        if path is None:
+            continue
+        try:
+            if path.stat().st_size > MAX_IMAGE_ATTACHMENT_BYTES:
+                LOGGER.warning(
+                    "Skipping Codex Assist image attachment over %s bytes: %s",
+                    MAX_IMAGE_ATTACHMENT_BYTES,
+                    path,
+                )
+                continue
+            images.append((mime_type, path.read_bytes()))
+        except OSError as err:
+            LOGGER.warning("Skipping unreadable Codex Assist image attachment %s: %s", path, err)
+    return images
 
 
 def _codex_tools_from_chat_log(chat_log: conversation.ChatLog) -> list[dict[str, Any]]:

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
   "requirements": ["httpx>=0.27.0"],
-  "version": "0.2.0-beta.2"
+  "version": "0.2.0-beta.3"
 }

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "codex_assist",
   "name": "Codex Assist",
-  "after_dependencies": ["conversation"],
+  "after_dependencies": ["ai_task", "conversation"],
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://github.com/itsreverence/ha-codex-assist",

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
   "requirements": ["httpx>=0.27.0"],
-  "version": "0.1.10"
+  "version": "0.2.0-beta.1"
 }

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
   "requirements": ["httpx>=0.27.0"],
-  "version": "0.2.0-beta.1"
+  "version": "0.2.0-beta.2"
 }

--- a/custom_components/codex_assist/strings.json
+++ b/custom_components/codex_assist/strings.json
@@ -5,9 +5,9 @@
         "title": "Codex Assist",
         "description": "Set the default model and prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
-          "model": "Model",
-          "image_model": "Image quality",
-          "image_size": "Image size",
+          "model": "Text model",
+          "image_model": "AI Task image quality",
+          "image_size": "AI Task image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -33,11 +33,11 @@
     "step": {
       "init": {
         "title": "Codex Assist options",
-        "description": "Adjust the Codex model, prompt, and advanced response behavior. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
+        "description": "Adjust text response settings first, then AI Task image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
-          "model": "Model",
-          "image_model": "Image quality",
-          "image_size": "Image size",
+          "model": "Text model",
+          "image_model": "AI Task image quality",
+          "image_size": "AI Task image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/custom_components/codex_assist/strings.json
+++ b/custom_components/codex_assist/strings.json
@@ -5,9 +5,9 @@
         "title": "Codex Assist",
         "description": "Set the default model and prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
-          "model": "Text model",
-          "image_model": "AI Task image quality",
-          "image_size": "AI Task image size",
+          "model": "Chat model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -33,11 +33,11 @@
     "step": {
       "init": {
         "title": "Codex Assist options",
-        "description": "Adjust text response settings first, then AI Task image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
+        "description": "Adjust chat response settings first, then image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
-          "model": "Text model",
-          "image_model": "AI Task image quality",
-          "image_size": "AI Task image size",
+          "model": "Chat model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/custom_components/codex_assist/strings.json
+++ b/custom_components/codex_assist/strings.json
@@ -6,6 +6,8 @@
         "description": "Set the default model and prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
           "model": "Model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -34,6 +36,8 @@
         "description": "Adjust the Codex model, prompt, and advanced response behavior. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
           "model": "Model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/custom_components/codex_assist/translations/en.json
+++ b/custom_components/codex_assist/translations/en.json
@@ -6,6 +6,8 @@
         "description": "Choose a default Codex model and system prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
           "model": "Model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -34,6 +36,8 @@
         "description": "Adjust the Codex model, prompt, and advanced response behavior. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
           "model": "Model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/custom_components/codex_assist/translations/en.json
+++ b/custom_components/codex_assist/translations/en.json
@@ -3,11 +3,11 @@
     "step": {
       "user": {
         "title": "Codex Assist",
-        "description": "Choose a default Codex model and system prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
+        "description": "Set the default model and prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
-          "model": "Model",
-          "image_model": "Image quality",
-          "image_size": "Image size",
+          "model": "Text model",
+          "image_model": "AI Task image quality",
+          "image_size": "AI Task image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -33,11 +33,11 @@
     "step": {
       "init": {
         "title": "Codex Assist options",
-        "description": "Adjust the Codex model, prompt, and advanced response behavior. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
+        "description": "Adjust text response settings first, then AI Task image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
-          "model": "Model",
-          "image_model": "Image quality",
-          "image_size": "Image size",
+          "model": "Text model",
+          "image_model": "AI Task image quality",
+          "image_size": "AI Task image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/custom_components/codex_assist/translations/en.json
+++ b/custom_components/codex_assist/translations/en.json
@@ -5,9 +5,9 @@
         "title": "Codex Assist",
         "description": "Set the default model and prompt. Setup will then show a Codex sign-in code for your ChatGPT/Codex account.",
         "data": {
-          "model": "Text model",
-          "image_model": "AI Task image quality",
-          "image_size": "AI Task image size",
+          "model": "Chat model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
@@ -33,11 +33,11 @@
     "step": {
       "init": {
         "title": "Codex Assist options",
-        "description": "Adjust text response settings first, then AI Task image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
+        "description": "Adjust chat response settings first, then image defaults. Codex Assist uses Home Assistant's normal Assist LLM control tools and respects Home Assistant's exposed-entity settings.",
         "data": {
-          "model": "Text model",
-          "image_model": "AI Task image quality",
-          "image_size": "AI Task image size",
+          "model": "Chat model",
+          "image_model": "Image quality",
+          "image_size": "Image size",
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -53,9 +53,9 @@ For generated documentation diagrams, prefer PNG/JPEG/WEBP for image-analysis to
 
 Do not publish screenshots that expose tokens, device codes, cookies, private Home Assistant URLs, private entity names, or private dashboard URLs.
 
-## Unreleased branch test install
+## Beta branch test install
 
-Use this for local testing only. Prefer this over cutting beta releases while a HACS default PR is waiting for review.
+Use this for local/beta testing while `main` stays on the stable `0.1.x` line for HACS default review.
 
 1. Download the branch archive:
 
@@ -71,7 +71,7 @@ Use this for local testing only. Prefer this over cutting beta releases while a 
    ```
 
 4. Restart Home Assistant.
-5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.2`; `main` remains on the latest stable `0.1.x` release for HACS review.
+5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.3`; `main` remains on the latest stable `0.1.x` release for HACS review.
 
 To roll back, reinstall the latest stable release from HACS and restart Home Assistant.
 
@@ -88,7 +88,7 @@ After a Home Assistant restart:
 
 ## Image attachment smoke test
 
-Use this only after installing the unreleased `v0.2-media-ai-task` branch.
+Use this only after installing the beta `v0.2-media-ai-task` branch.
 
 This is a defensive backend check, not a promise that the normal Home Assistant Assist pop-up has an upload button. Home Assistant conversation chat logs can carry `UserContent.attachments`, and provider integrations may translate them if they appear, but the public `conversation.process` schema does not currently accept attachments and `ConversationEntityFeature` has no attachment flag. Prefer AI Task for native attachment workflows.
 
@@ -113,16 +113,16 @@ Use this for the native HA AI Task media path on the `v0.2-media-ai-task` branch
 
 1. Restart Home Assistant after installing the branch.
 2. Confirm the integration exposes a Codex Assist AI Task entity.
-3. In integration options, confirm image controls are curated dropdowns:
-   - **Image quality**: Low, Medium, High
-   - **Image size**: Square (1024×1024), Landscape (1536×1024), Portrait (1024×1536)
+3. In integration options, confirm text settings appear first and image controls are curated dropdowns near the bottom:
+   - **AI Task image quality**: Low, Medium, High
+   - **AI Task image size**: Square (1024×1024), Landscape (1536×1024), Portrait (1024×1536)
 4. Call `ai_task.generate_data` with the Codex Assist AI Task entity, simple instructions, and a local media/camera/image attachment.
 5. Confirm the result references the attachment content.
 6. Call `ai_task.generate_image` with a plain prompt, then repeat once with a non-default size.
 7. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
 8. Confirm logs do not print tokens, local file contents, or base64 payloads.
 
-The v0.2 beta intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together. Keep image generation on the v0.2 branch until it passes real HA smoke tests; do not merge it into `main` while the HACS/default stable line is under review.
+The v0.2 beta intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together. Keep image generation on the v0.2 branch until the HACS/default stable line is clear or Larry explicitly decides to promote the beta into `main`.
 
 ## Reauth smoke test
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -90,6 +90,8 @@ After a Home Assistant restart:
 
 Use this only after installing the unreleased `v0.2-media-ai-task` branch.
 
+This is a defensive backend check, not a promise that the normal Home Assistant Assist pop-up has an upload button. Home Assistant conversation chat logs can carry `UserContent.attachments`, and provider integrations may translate them if they appear, but the public `conversation.process` schema does not currently accept attachments and `ConversationEntityFeature` has no attachment flag. Prefer AI Task for native attachment workflows.
+
 1. Reauth Codex Assist if Home Assistant shows a repair or auth failure.
 2. Select an Assist/chat surface that exposes attachment upload for conversation agents. Home Assistant's normal voice Assist pop-up may not show an upload button; that means the UI surface cannot exercise conversation attachments directly, not necessarily that the integration backend is missing image support.
 3. Attach a small PNG/JPEG image under 10 MB if the surface exposes an upload control.
@@ -104,6 +106,19 @@ Use this only after installing the unreleased `v0.2-media-ai-task` branch.
 7. Try the same prompt without an image and confirm normal text-only Assist still works.
 
 If the Assist UI you are using has no attachment button, the backend support is present but that UI surface cannot exercise it directly. Home Assistant AI Task has explicit `SUPPORT_ATTACHMENTS` feature support, so AI Task is the preferred native surface for future image/PDF smoke tests.
+
+## AI Task attachment smoke test
+
+Use this for the native HA attachment path on the `v0.2-media-ai-task` branch.
+
+1. Restart Home Assistant after installing the branch.
+2. Confirm the integration exposes a Codex Assist AI Task entity.
+3. Call `ai_task.generate_data` with the Codex Assist AI Task entity, simple instructions, and a local media/camera/image attachment.
+4. Confirm the result references the attachment content.
+5. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
+6. Confirm logs do not print tokens, local file contents, or base64 payloads.
+
+Do not advertise `GENERATE_IMAGE` unless Codex Assist intentionally supports image generation output. For v0.2, the intended scope is data generation from text plus image attachments.
 
 ## Reauth smoke test
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -71,7 +71,7 @@ Use this for local testing only. Prefer this over cutting beta releases while a 
    ```
 
 4. Restart Home Assistant.
-5. Confirm the integration version/logs reflect the branch code before testing.
+5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.1`; `main` remains on the latest stable `0.1.x` release for HACS review.
 
 To roll back, reinstall the latest stable release from HACS and restart Home Assistant.
 
@@ -91,8 +91,8 @@ After a Home Assistant restart:
 Use this only after installing the unreleased `v0.2-media-ai-task` branch.
 
 1. Reauth Codex Assist if Home Assistant shows a repair or auth failure.
-2. Select an Assist surface that exposes attachment upload for conversation agents.
-3. Attach a small PNG/JPEG image under 10 MB.
+2. Select an Assist/chat surface that exposes attachment upload for conversation agents. Home Assistant's normal voice Assist pop-up may not show an upload button; that means the UI surface cannot exercise conversation attachments directly, not necessarily that the integration backend is missing image support.
+3. Attach a small PNG/JPEG image under 10 MB if the surface exposes an upload control.
 4. Ask a visual question such as:
 
    ```text
@@ -103,7 +103,7 @@ Use this only after installing the unreleased `v0.2-media-ai-task` branch.
 6. Confirm Home Assistant logs do not show `codex_assist` attachment/read errors.
 7. Try the same prompt without an image and confirm normal text-only Assist still works.
 
-If the Assist UI you are using has no attachment button, the backend support is present but that UI surface cannot exercise it directly.
+If the Assist UI you are using has no attachment button, the backend support is present but that UI surface cannot exercise it directly. Home Assistant AI Task has explicit `SUPPORT_ATTACHMENTS` feature support, so AI Task is the preferred native surface for future image/PDF smoke tests.
 
 ## Reauth smoke test
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -113,9 +113,9 @@ Use this for the native HA AI Task media path on the `v0.2-media-ai-task` branch
 
 1. Restart Home Assistant after installing the branch.
 2. Confirm the integration exposes a Codex Assist AI Task entity.
-3. In integration options, confirm text settings appear first and image controls are curated dropdowns near the bottom:
-   - **AI Task image quality**: Low, Medium, High
-   - **AI Task image size**: Square (1024×1024), Landscape (1536×1024), Portrait (1024×1536)
+3. In integration options, confirm chat settings appear first and image controls are curated dropdowns near the bottom:
+   - **Image quality**: Low, Medium, High
+   - **Image size**: Square (1024×1024), Landscape (1536×1024), Portrait (1024×1536)
 4. Call `ai_task.generate_data` with the Codex Assist AI Task entity, simple instructions, and a local media/camera/image attachment.
 5. Confirm the result references the attachment content.
 6. Call `ai_task.generate_image` with a plain prompt, then repeat once with a non-default size.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -107,16 +107,20 @@ This is a defensive backend check, not a promise that the normal Home Assistant 
 
 If the Assist UI you are using has no attachment button, the backend support is present but that UI surface cannot exercise it directly. Home Assistant AI Task has explicit `SUPPORT_ATTACHMENTS` feature support, so AI Task is the preferred native surface for future image/PDF smoke tests.
 
-## AI Task attachment smoke test
+## AI Task media smoke test
 
-Use this for the native HA attachment path on the `v0.2-media-ai-task` branch.
+Use this for the native HA AI Task media path on the `v0.2-media-ai-task` branch.
 
 1. Restart Home Assistant after installing the branch.
 2. Confirm the integration exposes a Codex Assist AI Task entity.
-3. Call `ai_task.generate_data` with the Codex Assist AI Task entity, simple instructions, and a local media/camera/image attachment.
-4. Confirm the result references the attachment content.
-5. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
-6. Confirm logs do not print tokens, local file contents, or base64 payloads.
+3. In integration options, confirm image controls are curated dropdowns:
+   - **Image quality**: Low, Medium, High
+   - **Image size**: Square (1024×1024), Landscape (1536×1024), Portrait (1024×1536)
+4. Call `ai_task.generate_data` with the Codex Assist AI Task entity, simple instructions, and a local media/camera/image attachment.
+5. Confirm the result references the attachment content.
+6. Call `ai_task.generate_image` with a plain prompt, then repeat once with a non-default size.
+7. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
+8. Confirm logs do not print tokens, local file contents, or base64 payloads.
 
 The v0.2 beta intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together. Keep image generation on the v0.2 branch until it passes real HA smoke tests; do not merge it into `main` while the HACS/default stable line is under review.
 
@@ -136,5 +140,5 @@ When changing model configuration or before a release that includes model select
 1. Start setup/options without a usable token and confirm the curated fallback models appear.
 2. Complete auth and reopen options.
 3. Confirm backend-discovered models appear when the Codex backend returns them.
-4. Confirm a custom model slug can still be retained or entered manually.
+4. Confirm a stale saved model that is no longer in the discovered/fallback list is replaced with the default model instead of being silently re-added.
 5. Confirm failed model discovery falls back gracefully and does not block setup.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -53,6 +53,28 @@ For generated documentation diagrams, prefer PNG/JPEG/WEBP for image-analysis to
 
 Do not publish screenshots that expose tokens, device codes, cookies, private Home Assistant URLs, private entity names, or private dashboard URLs.
 
+## Unreleased branch test install
+
+Use this for local testing only. Prefer this over cutting beta releases while a HACS default PR is waiting for review.
+
+1. Download the branch archive:
+
+   ```text
+   https://github.com/itsreverence/ha-codex-assist/archive/refs/heads/v0.2-media-ai-task.zip
+   ```
+
+2. Extract the zip locally.
+3. Copy the extracted `custom_components/codex_assist` directory into Home Assistant:
+
+   ```text
+   /config/custom_components/codex_assist
+   ```
+
+4. Restart Home Assistant.
+5. Confirm the integration version/logs reflect the branch code before testing.
+
+To roll back, reinstall the latest stable release from HACS and restart Home Assistant.
+
 ## Post-install smoke test
 
 After a Home Assistant restart:
@@ -63,6 +85,25 @@ After a Home Assistant restart:
 4. Ask it to list exposed entities.
 5. Test one harmless exposed light on/off.
 6. Confirm sensitive entities remain unexposed unless intentionally allowed.
+
+## Image attachment smoke test
+
+Use this only after installing the unreleased `v0.2-media-ai-task` branch.
+
+1. Reauth Codex Assist if Home Assistant shows a repair or auth failure.
+2. Select an Assist surface that exposes attachment upload for conversation agents.
+3. Attach a small PNG/JPEG image under 10 MB.
+4. Ask a visual question such as:
+
+   ```text
+   What is in this image? Do not control any devices.
+   ```
+
+5. Confirm the answer references actual image content.
+6. Confirm Home Assistant logs do not show `codex_assist` attachment/read errors.
+7. Try the same prompt without an image and confirm normal text-only Assist still works.
+
+If the Assist UI you are using has no attachment button, the backend support is present but that UI surface cannot exercise it directly.
 
 ## Reauth smoke test
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -71,7 +71,7 @@ Use this for local testing only. Prefer this over cutting beta releases while a 
    ```
 
 4. Restart Home Assistant.
-5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.1`; `main` remains on the latest stable `0.1.x` release for HACS review.
+5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.2`; `main` remains on the latest stable `0.1.x` release for HACS review.
 
 To roll back, reinstall the latest stable release from HACS and restart Home Assistant.
 
@@ -118,7 +118,7 @@ Use this for the native HA attachment path on the `v0.2-media-ai-task` branch.
 5. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
 6. Confirm logs do not print tokens, local file contents, or base64 payloads.
 
-Do not advertise `GENERATE_IMAGE` unless Codex Assist intentionally supports image generation output. For v0.2, the intended scope is data generation from text plus image attachments.
+The v0.2 beta intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together. Keep image generation on the v0.2 branch until it passes real HA smoke tests; do not merge it into `main` while the HACS/default stable line is under review.
 
 ## Reauth smoke test
 

--- a/tests/test_ai_task_source.py
+++ b/tests/test_ai_task_source.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+AI_TASK_SOURCE = Path("custom_components/codex_assist/ai_task.py").read_text()
+CONVERSATION_SOURCE = Path("custom_components/codex_assist/conversation.py").read_text()
+
+
+def test_ai_task_declares_native_attachment_support_without_image_generation_output():
+    assert "ai_task.AITaskEntity" in AI_TASK_SOURCE
+    assert "AITaskEntityFeature.GENERATE_DATA" in AI_TASK_SOURCE
+    assert "AITaskEntityFeature.SUPPORT_ATTACHMENTS" in AI_TASK_SOURCE
+    assert "AITaskEntityFeature.GENERATE_IMAGE" not in AI_TASK_SOURCE
+
+
+def test_ai_task_uses_ha_chat_log_attachment_path():
+    assert "ai_task.GenDataTask" in AI_TASK_SOURCE
+    assert "_codex_input_from_chat_log" in AI_TASK_SOURCE
+    assert "task.structure" in AI_TASK_SOURCE
+    assert "GenDataTaskResult" in AI_TASK_SOURCE
+
+
+def test_conversation_attachment_handling_remains_defensive_only():
+    assert "getattr(content, \"attachments\", None)" in CONVERSATION_SOURCE
+    assert "_async_image_attachments_for_codex" in CONVERSATION_SOURCE
+    assert "ConversationEntityFeature.CONTROL" in CONVERSATION_SOURCE
+    assert "SUPPORT_ATTACHMENTS" not in CONVERSATION_SOURCE

--- a/tests/test_ai_task_source.py
+++ b/tests/test_ai_task_source.py
@@ -12,6 +12,9 @@ def test_ai_task_declares_native_attachment_and_image_generation_support():
     assert "_async_generate_image" in AI_TASK_SOURCE
     assert "DEFAULT_IMAGE_MODEL" in AI_TASK_SOURCE
     assert "DEFAULT_IMAGE_SIZE" in AI_TASK_SOURCE
+    assert "image_size_dimensions" in AI_TASK_SOURCE
+    assert "width=width" in AI_TASK_SOURCE
+    assert "height=height" in AI_TASK_SOURCE
 
 
 def test_ai_task_uses_ha_chat_log_attachment_path():

--- a/tests/test_ai_task_source.py
+++ b/tests/test_ai_task_source.py
@@ -4,11 +4,13 @@ AI_TASK_SOURCE = Path("custom_components/codex_assist/ai_task.py").read_text()
 CONVERSATION_SOURCE = Path("custom_components/codex_assist/conversation.py").read_text()
 
 
-def test_ai_task_declares_native_attachment_support_without_image_generation_output():
+def test_ai_task_declares_native_attachment_and_image_generation_support():
     assert "ai_task.AITaskEntity" in AI_TASK_SOURCE
     assert "AITaskEntityFeature.GENERATE_DATA" in AI_TASK_SOURCE
+    assert "AITaskEntityFeature.GENERATE_IMAGE" in AI_TASK_SOURCE
     assert "AITaskEntityFeature.SUPPORT_ATTACHMENTS" in AI_TASK_SOURCE
-    assert "AITaskEntityFeature.GENERATE_IMAGE" not in AI_TASK_SOURCE
+    assert "_async_generate_image" in AI_TASK_SOURCE
+    assert "gpt-image-2-medium" in AI_TASK_SOURCE
 
 
 def test_ai_task_uses_ha_chat_log_attachment_path():

--- a/tests/test_ai_task_source.py
+++ b/tests/test_ai_task_source.py
@@ -10,7 +10,8 @@ def test_ai_task_declares_native_attachment_and_image_generation_support():
     assert "AITaskEntityFeature.GENERATE_IMAGE" in AI_TASK_SOURCE
     assert "AITaskEntityFeature.SUPPORT_ATTACHMENTS" in AI_TASK_SOURCE
     assert "_async_generate_image" in AI_TASK_SOURCE
-    assert "gpt-image-2-medium" in AI_TASK_SOURCE
+    assert "DEFAULT_IMAGE_MODEL" in AI_TASK_SOURCE
+    assert "DEFAULT_IMAGE_SIZE" in AI_TASK_SOURCE
 
 
 def test_ai_task_uses_ha_chat_log_attachment_path():

--- a/tests/test_codex_client_attachments.py
+++ b/tests/test_codex_client_attachments.py
@@ -1,0 +1,24 @@
+import base64
+
+from custom_components.codex_assist.codex_client import codex_user_content_with_images
+
+
+def test_codex_user_content_with_images_returns_plain_text_without_images():
+    assert codex_user_content_with_images("describe this", []) == "describe this"
+
+
+def test_codex_user_content_with_images_encodes_images_as_responses_input_image_items():
+    content = codex_user_content_with_images(
+        "describe this",
+        [("image/png", b"fake-png-bytes")],
+    )
+
+    assert content == [
+        {"type": "input_text", "text": "describe this"},
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64,"
+            + base64.b64encode(b"fake-png-bytes").decode("ascii"),
+            "detail": "auto",
+        },
+    ]

--- a/tests/test_codex_client_image_generation.py
+++ b/tests/test_codex_client_image_generation.py
@@ -86,6 +86,7 @@ async def test_generate_image_uses_codex_responses_image_generation_tool():
         ],
         chat_model="gpt-5.4",
         image_model="gpt-image-2-high",
+        size="1536x1024",
     )
 
     assert result.image_data == image_data
@@ -104,7 +105,7 @@ async def test_generate_image_uses_codex_responses_image_generation_tool():
         {
             "type": "image_generation",
             "model": "gpt-image-2",
-            "size": "1024x1024",
+            "size": "1536x1024",
             "quality": "high",
             "output_format": "png",
             "background": "opaque",
@@ -137,6 +138,20 @@ async def test_generate_image_accepts_partial_image_b64_events_without_type():
     result = await client.generate_image(prompt="draw it")
 
     assert result.image_data == image_data
+
+
+@pytest.mark.asyncio
+async def test_generate_image_rejects_unsupported_image_options_before_request():
+    client = CodexClient(
+        http_client=FakeHttpClient(FakeStreamResponse()),
+        access_token="token-1",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported Codex Assist image model"):
+        await client.generate_image(prompt="draw it", image_model="gpt-image-2-ultra")
+
+    with pytest.raises(ValueError, match="Unsupported Codex Assist image size"):
+        await client.generate_image(prompt="draw it", size="2048x2048")
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_client_image_generation.py
+++ b/tests/test_codex_client_image_generation.py
@@ -1,0 +1,152 @@
+import base64
+import json
+
+import pytest
+
+from custom_components.codex_assist.codex_client import CodexClient
+
+
+class FakeStreamResponse:
+    def __init__(self, status_code=200, lines=None, error_body=b""):
+        self.status_code = status_code
+        self._lines = lines or []
+        self._error_body = error_body
+
+    async def aiter_lines(self):
+        for line in self._lines:
+            yield line
+
+    async def aread(self):
+        return self._error_body
+
+
+class FakeStreamContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeHttpClient:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    async def post(self, url, **kwargs):
+        raise AssertionError("generate_image should stream, not post")
+
+    def stream(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return FakeStreamContext(self.response)
+
+
+def _event(event_type, payload):
+    return [
+        f"event: {event_type}",
+        f"data: {json.dumps(payload)}",
+        "",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_image_uses_codex_responses_image_generation_tool():
+    image_data = b"fake-png-bytes"
+    image_b64 = base64.b64encode(image_data).decode("ascii")
+    response = FakeStreamResponse(
+        lines=(
+            _event("response.output_text.delta", {"delta": "A generated image."})
+            + _event(
+                "response.output_item.done",
+                {
+                    "item": {
+                        "type": "image_generation_call",
+                        "result": image_b64,
+                    }
+                },
+            )
+            + ["data: [DONE]", ""]
+        )
+    )
+    http = FakeHttpClient(response)
+    client = CodexClient(http_client=http, access_token="token-1")
+
+    result = await client.generate_image(
+        prompt="draw a tidy smart home dashboard icon",
+        input_items=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "draw a tidy smart home dashboard icon"}
+                ],
+            }
+        ],
+        chat_model="gpt-5.4",
+        image_model="gpt-image-2-high",
+    )
+
+    assert result.image_data == image_data
+    assert result.mime_type == "image/png"
+    assert result.model == "gpt-image-2-high"
+    assert result.revised_prompt == "A generated image."
+
+    method, url, kwargs = http.calls[0]
+    payload = kwargs["json"]
+    assert method == "POST"
+    assert url == "https://chatgpt.com/backend-api/codex/responses"
+    assert kwargs["headers"]["Accept"] == "text/event-stream"
+    assert payload["model"] == "gpt-5.4"
+    assert payload["stream"] is True
+    assert payload["tools"] == [
+        {
+            "type": "image_generation",
+            "model": "gpt-image-2",
+            "size": "1024x1024",
+            "quality": "high",
+            "output_format": "png",
+            "background": "opaque",
+            "partial_images": 1,
+        }
+    ]
+    assert payload["tool_choice"] == {
+        "type": "allowed_tools",
+        "mode": "required",
+        "tools": [{"type": "image_generation"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_image_accepts_partial_image_b64_events_without_type():
+    image_data = b"partial-image"
+    payload = {"partial_image_b64": base64.b64encode(image_data).decode("ascii")}
+    response = FakeStreamResponse(
+        lines=[
+            "event: response.image_generation_call.partial_image",
+            f"data: {json.dumps(payload)}",
+            "",
+        ]
+    )
+    client = CodexClient(
+        http_client=FakeHttpClient(response),
+        access_token="token-1",
+    )
+
+    result = await client.generate_image(prompt="draw it")
+
+    assert result.image_data == image_data
+
+
+@pytest.mark.asyncio
+async def test_generate_image_raises_when_stream_has_no_image_result():
+    client = CodexClient(
+        http_client=FakeHttpClient(
+            FakeStreamResponse(lines=_event("response.completed", {"type": "response.completed"}))
+        ),
+        access_token="token-1",
+    )
+
+    with pytest.raises(RuntimeError, match="no image_generation result"):
+        await client.generate_image(prompt="draw it")

--- a/tests/test_codex_image.py
+++ b/tests/test_codex_image.py
@@ -1,0 +1,20 @@
+import pytest
+
+from custom_components.codex_assist.codex_image import (
+    image_size_dimensions,
+    validate_image_size,
+)
+
+
+def test_image_size_dimensions_returns_width_and_height():
+    assert image_size_dimensions("1536x1024") == (1536, 1024)
+    assert image_size_dimensions("1024x1536") == (1024, 1536)
+
+
+def test_image_size_dimensions_rejects_unsupported_size():
+    with pytest.raises(ValueError, match="Unsupported Codex Assist image size"):
+        image_size_dimensions("2048x2048")
+
+
+def test_validate_image_size_returns_supported_size():
+    assert validate_image_size("1024x1024") == "1024x1024"

--- a/tests/test_conversation_history_source.py
+++ b/tests/test_conversation_history_source.py
@@ -27,3 +27,12 @@ def test_conversation_enables_full_home_assistant_assist_control():
     assert "ConversationEntityFeature.CONTROL" in source
     assert "llm.LLM_API_ASSIST" in source
     assert "_codex_tools_from_chat_log" in source
+
+
+def test_conversation_translates_home_assistant_image_attachments_to_codex_input():
+    source = CONVERSATION.read_text()
+
+    assert "_async_image_attachments_for_codex" in source
+    assert "mime_type.startswith(\"image/\")" in source
+    assert "codex_user_content_with_images" in source
+    assert "MAX_IMAGE_ATTACHMENT_BYTES" in source

--- a/tests/test_integration_scaffold.py
+++ b/tests/test_integration_scaffold.py
@@ -9,11 +9,13 @@ def test_manifest_is_hacs_loadable_custom_integration():
     assert manifest["name"] == "Codex Assist"
     assert manifest["config_flow"] is True
     assert "conversation" in manifest["after_dependencies"]
+    assert "ai_task" in manifest["after_dependencies"]
     assert "httpx" in " ".join(manifest["requirements"])
 
 
-def test_integration_declares_conversation_platform_forwarding():
+def test_integration_declares_conversation_and_ai_task_platform_forwarding():
     init_py = Path("custom_components/codex_assist/__init__.py").read_text()
 
     assert "Platform.CONVERSATION" in init_py
+    assert "Platform.AI_TASK" in init_py
     assert "async_forward_entry_setups" in init_py

--- a/tests/test_options_flow_source.py
+++ b/tests/test_options_flow_source.py
@@ -14,13 +14,13 @@ def test_config_flow_exposes_options_flow_for_runtime_settings():
     assert "self.config_entry = config_entry" not in source
 
 
-def test_options_flow_uses_codex_model_selector_with_custom_slug_fallback():
+def test_options_flow_uses_codex_model_selector_without_custom_slug_footgun():
     source = CONFIG_FLOW.read_text()
 
     assert "fetch_codex_model_ids" in source
     assert "SelectSelector" in source
     assert "SelectSelectorMode.DROPDOWN" in source
-    assert "custom_value=True" in source
+    assert "custom_value=True" not in source
 
 
 def test_options_flow_exposes_advanced_codex_response_controls():
@@ -31,6 +31,19 @@ def test_options_flow_exposes_advanced_codex_response_controls():
     assert "CONF_TEXT_VERBOSITY" in source
     assert '["low", "medium", "high"]' in source
     assert '["auto", "concise", "detailed", "off"]' in source
+
+
+def test_options_flow_exposes_image_generation_controls():
+    source = CONFIG_FLOW.read_text()
+
+    assert "CONF_IMAGE_MODEL" in source
+    assert "CONF_IMAGE_SIZE" in source
+    assert "gpt-image-2-low" in source
+    assert "gpt-image-2-medium" in source
+    assert "gpt-image-2-high" in source
+    assert "1024x1024" in source
+    assert "1536x1024" in source
+    assert "1024x1536" in source
 
 
 def test_options_flow_does_not_expose_redundant_safety_mode_choice():


### PR DESCRIPTION
## Summary
- Add a native Home Assistant AI Task entity for Codex Assist
- Support `ai_task.generate_data`, `ai_task.generate_image`, and HA-native attachments
- Add configurable image quality/size defaults
- Return generated image metadata including width/height
- Keep normal Assist safety on Home Assistant exposed-entity controls

## Real HA smoke test evidence
Tested on Home Assistant 2026.5.4:
- Normal Assist sanity prompt passed
- `ai_task.generate_data` returned expected text
- `ai_task.generate_image` produced a PNG image
- Non-default landscape image size produced an image
- Attachment understanding worked using a generated image
- Image generation with attachment worked

## Local verification
- `uv run pytest -q` → 65 passed
- `uv run ruff check .` → clean
- `docker run --rm -v "$PWD:/github/workspace" ghcr.io/home-assistant/hassfest` → Invalid integrations: 0

## Notes
The Codex/ChatGPT service interface remains unofficial/experimental, but the new surface uses Home Assistant's native AI Task APIs and preserves the existing exposed-entity safety model for normal Assist control.
