### PR TITLE
Prepare v0.2 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Requirements: Home Assistant `2026.5.0` or newer, HACS, and a ChatGPT account/pl
 - Ask about exposed entity state and request simple actions in the same Assist chat.
 - Stream replies in Assist while Codex is answering.
 - Configure model, prompt, reasoning effort, reasoning summary, and text verbosity from the integration options flow.
-- On the v0.2 media branch, test native AI Task attachment handling and subscription-backed image generation with curated image quality and size controls.
+- Use Home Assistant AI Task for structured data generation, attachment-aware prompts, and subscription-backed image generation with curated image quality and size controls.
 
 <p align="center">
   <img src="assets/codex-assist-light-control.png" alt="Codex Assist confirming yard lights are on and turning them off" width="430">
@@ -87,4 +87,4 @@ uv run ruff check .
 uv run pytest
 ```
 
-Current release: `v0.1.10`.
+Current stable candidate: `v0.2.0`.

--- a/README.md
+++ b/README.md
@@ -87,4 +87,4 @@ uv run ruff check .
 uv run pytest
 ```
 
-Current stable candidate: `v0.2.0`.
+Current release: `v0.2.0`.

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
   "requirements": ["httpx>=0.27.0"],
-  "version": "0.2.0-beta.3"
+  "version": "0.2.0"
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,6 +9,7 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 - **Config flow**: handles Codex-style device-code sign-in, stores OAuth tokens in the Home Assistant config entry, and exposes options such as the selected Codex model.
 - **Model discovery**: offers a curated fallback model list and, when authenticated, asks the Codex backend for the currently available model IDs.
 - **Conversation agent**: registers `conversation.codex_assist` so Codex Assist can be selected in Home Assistant Assist pipelines.
+- **AI Task entity**: registers a native AI Task provider for structured data generation, attachment-aware prompts, and image generation.
 - **Codex client**: refreshes tokens when possible and sends conversation turns to the Codex-compatible service interface.
 - **Assist tool bridge**: maps model-requested actions into Home Assistant's Assist LLM API rather than calling services directly.
 
@@ -20,6 +21,15 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 4. If Codex requests a Home Assistant tool call, Codex Assist maps that request into Home Assistant's Assist LLM API.
 5. Home Assistant validates and executes the allowed Assist tool call using its normal exposed-entity controls.
 6. Codex Assist returns the final response to Home Assistant.
+
+## AI Task flow
+
+1. Home Assistant sends an AI Task request to the Codex Assist AI Task entity.
+2. For data-generation tasks, Codex Assist translates instructions and supported attachments into Codex-compatible input items.
+3. For image-generation tasks, Codex Assist requests an image from the Codex-compatible service interface using curated quality and size options.
+4. Codex Assist returns the structured data or generated image bytes through Home Assistant's native AI Task result types.
+
+Normal Assist conversation surfaces may not expose an upload button even though Home Assistant chat-log objects can carry attachments internally. Native attachment testing should use AI Task surfaces that advertise attachment support.
 
 ## Security boundary
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -53,14 +53,14 @@ For generated documentation diagrams, prefer PNG/JPEG/WEBP for image-analysis to
 
 Do not publish screenshots that expose tokens, device codes, cookies, private Home Assistant URLs, private entity names, or private dashboard URLs.
 
-## Beta branch test install
+## Release-candidate test install
 
-Use this for local/beta testing while `main` stays on the stable `0.1.x` line for HACS default review.
+Use this for local release-candidate testing before cutting a stable GitHub release.
 
-1. Download the branch archive:
+1. Download the branch or tag archive you plan to test:
 
    ```text
-   https://github.com/itsreverence/ha-codex-assist/archive/refs/heads/v0.2-media-ai-task.zip
+   https://github.com/itsreverence/ha-codex-assist/archive/refs/heads/main.zip
    ```
 
 2. Extract the zip locally.
@@ -71,7 +71,7 @@ Use this for local/beta testing while `main` stays on the stable `0.1.x` line fo
    ```
 
 4. Restart Home Assistant.
-5. Confirm the integration version/logs reflect the branch code before testing. The `v0.2-media-ai-task` branch uses a beta manifest version such as `0.2.0-beta.3`; `main` remains on the latest stable `0.1.x` release for HACS review.
+5. Confirm the integration version/logs reflect the candidate code before testing.
 
 To roll back, reinstall the latest stable release from HACS and restart Home Assistant.
 
@@ -88,7 +88,7 @@ After a Home Assistant restart:
 
 ## Image attachment smoke test
 
-Use this only after installing the beta `v0.2-media-ai-task` branch.
+Use this after installing a build that includes Codex Assist AI Task support.
 
 This is a defensive backend check, not a promise that the normal Home Assistant Assist pop-up has an upload button. Home Assistant conversation chat logs can carry `UserContent.attachments`, and provider integrations may translate them if they appear, but the public `conversation.process` schema does not currently accept attachments and `ConversationEntityFeature` has no attachment flag. Prefer AI Task for native attachment workflows.
 
@@ -109,9 +109,9 @@ If the Assist UI you are using has no attachment button, the backend support is 
 
 ## AI Task media smoke test
 
-Use this for the native HA AI Task media path on the `v0.2-media-ai-task` branch.
+Use this for the native Home Assistant AI Task media path.
 
-1. Restart Home Assistant after installing the branch.
+1. Restart Home Assistant after installing the candidate build.
 2. Confirm the integration exposes a Codex Assist AI Task entity.
 3. In integration options, confirm chat settings appear first and image controls are curated dropdowns near the bottom:
    - **Image quality**: Low, Medium, High
@@ -122,7 +122,7 @@ Use this for the native HA AI Task media path on the `v0.2-media-ai-task` branch
 7. Confirm an attachment request is accepted because the entity advertises `AITaskEntityFeature.SUPPORT_ATTACHMENTS`.
 8. Confirm logs do not print tokens, local file contents, or base64 payloads.
 
-The v0.2 beta intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together. Keep image generation on the v0.2 branch until the HACS/default stable line is clear or Larry explicitly decides to promote the beta into `main`.
+The v0.2 line intentionally advertises `GENERATE_DATA`, `GENERATE_IMAGE`, and `SUPPORT_ATTACHMENTS` so one AI Task entity can smoke-test text/data generation, image attachment understanding, and Codex/ChatGPT subscription-backed image output together.
 
 ## Reauth smoke test
 


### PR DESCRIPTION
## Summary
- promote the manifest version from v0.2 beta to 0.2.0
- remove stale beta-branch wording from README and workflow docs
- document the native AI Task architecture and stable smoke-test path

## Verification
- uv run ruff check .
- uv run pytest -q
- docker run --rm -v "/home/laptop/ha-codex-assist:/github/workspace" ghcr.io/home-assistant/hassfest
- hacs/action against release-v0.2.0-polish