### PR TITLE
Continue conversation after Assist tool calls

### DIFF
--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 import httpx
@@ -115,7 +115,7 @@ class CodexAssistConversationEntity(
         try:
             for _iteration in range(MAX_TOOL_ITERATIONS):
                 try:
-                    await _stream_codex_turn_into_chat_log(
+                    tool_call_requested = await _stream_codex_turn_into_chat_log(
                         chat_log=chat_log,
                         codex=codex,
                         entity_id=self.entity_id or "",
@@ -155,7 +155,7 @@ class CodexAssistConversationEntity(
                         access_token=tokens.access_token,
                     )
                     try:
-                        await _stream_codex_turn_into_chat_log(
+                        tool_call_requested = await _stream_codex_turn_into_chat_log(
                             chat_log=chat_log,
                             codex=codex,
                             entity_id=self.entity_id or "",
@@ -179,7 +179,7 @@ class CodexAssistConversationEntity(
                             response,
                             user_input,
                         )
-                if not chat_log.unresponded_tool_results:
+                if not tool_call_requested:
                     break
         except (httpx.HTTPError, RuntimeError) as err:
             LOGGER.exception("Codex Assist model request failed")
@@ -215,7 +215,13 @@ async def _stream_codex_turn_into_chat_log(
     reasoning_effort: str,
     reasoning_summary: str,
     text_verbosity: str,
-) -> None:
+) -> bool:
+    tool_call_requested = False
+
+    def mark_tool_call_requested() -> None:
+        nonlocal tool_call_requested
+        tool_call_requested = True
+
     async for _delta in chat_log.async_add_delta_content_stream(
         entity_id,
         _codex_stream_to_assistant_deltas(
@@ -227,14 +233,18 @@ async def _stream_codex_turn_into_chat_log(
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
-            )
+            ),
+            on_tool_call=mark_tool_call_requested,
         ),
     ):
         pass
+    return tool_call_requested
 
 
 async def _codex_stream_to_assistant_deltas(
     stream: AsyncIterator[CodexStreamDelta],
+    *,
+    on_tool_call: Callable[[], None] | None = None,
 ) -> AsyncIterator[AssistantContentDeltaDict]:
     started = False
     async for delta in stream:
@@ -244,6 +254,8 @@ async def _codex_stream_to_assistant_deltas(
         if isinstance(delta, CodexTextDelta):
             yield {"content": delta.text}
         elif isinstance(delta, CodexToolCallDelta):
+            if on_tool_call is not None:
+                on_tool_call()
             yield {
                 "tool_calls": [
                     llm.ToolInput(

--- a/tests/test_conversation_history_source.py
+++ b/tests/test_conversation_history_source.py
@@ -18,6 +18,9 @@ def test_conversation_streams_assistant_reply_and_executes_tools_in_chat_log():
     assert "_attr_supports_streaming = True" in source
     assert "async_add_delta_content_stream" in source
     assert "_codex_stream_to_assistant_deltas" in source
+    assert "tool_call_requested = await _stream_codex_turn_into_chat_log" in source
+    assert "if not tool_call_requested:" in source
+    assert "on_tool_call=mark_tool_call_requested" in source
     assert "llm.ToolInput" in source
 
 


### PR DESCRIPTION
## Summary
- Track whether a Codex streaming turn requested a Home Assistant tool call.
- Continue the conversation loop after tool calls so the model sees returned tool results and produces the final answer in the same Assist turn.
- Keep existing stop behavior for turns that only stream text.

## Why
Home Assistant may consume/store script tool results immediately, leaving `chat_log.unresponded_tool_results` empty by the time Codex Assist checks it. In that case Codex Assist stopped after the tool call and the UI stayed at `...` until the next user message.

Tracking whether the model requested a tool call during the stream is the better signal that a follow-up model pass is needed.

## Verification
- `uv run ruff check .`
- `uv run pytest -q`
