### PR TITLE
Update default HACS install docs and drop bundled httpx

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/itsreverence/ha-codex-assist/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/itsreverence/ha-codex-assist?style=for-the-badge"></a>
   <a href="https://github.com/itsreverence/ha-codex-assist/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/itsreverence/ha-codex-assist/ci.yml?branch=main&style=for-the-badge&label=CI"></a>
-  <img alt="HACS custom repository" src="https://img.shields.io/badge/HACS-Custom-orange?style=for-the-badge">
+  <a href="https://www.hacs.xyz/docs/use/repositories/dashboard/"><img alt="Available in HACS" src="https://img.shields.io/badge/HACS-Default-41BDF5?style=for-the-badge"></a>
 </p>
 
 Use OpenAI Codex / ChatGPT as a Home Assistant Assist conversation agent.
@@ -20,23 +20,19 @@ Codex Assist signs in with Codex-style ChatGPT device-code auth, adds Codex as a
 
 Requirements: Home Assistant `2026.5.0` or newer, HACS, and a ChatGPT account/plan with Codex access.
 
-[![Open this repository in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=itsreverence&repository=ha-codex-assist&category=integration)
+[![Open HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=itsreverence&repository=ha-codex-assist&category=integration)
 [![Add the Codex Assist integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=codex_assist)
 
-1. In Home Assistant, open **HACS → Custom repositories**.
-2. Add this repository as an **Integration**:
+1. In Home Assistant, open **HACS → Integrations**.
+2. Search for **Codex Assist**, open it, and select **Download**.
+3. Restart Home Assistant.
+4. In ChatGPT, enable **Settings → Security → Enable device code authorization for Codex** if it is available on your account.
+5. Go to **Settings → Devices & services → Add integration**, or use the button above.
+6. Search for **Codex Assist** and complete device-code sign-in.
+7. Select **Codex Assist** in your Assist pipeline.
+8. Test with a harmless exposed entity first, like a single light.
 
-   ```text
-   https://github.com/itsreverence/ha-codex-assist
-   ```
-
-3. Install **Codex Assist**.
-4. Restart Home Assistant.
-5. In ChatGPT, enable **Settings → Security → Enable device code authorization for Codex** if it is available on your account.
-6. Go to **Settings → Devices & services → Add integration**, or use the button above.
-7. Search for **Codex Assist** and complete device-code sign-in.
-8. Select **Codex Assist** in your Assist pipeline.
-9. Test with a harmless exposed entity first, like a single light.
+Codex Assist is included in HACS by default; you do not need to add this GitHub repository as a custom repository. If it does not appear immediately after a new release or catalog change, refresh HACS data and try again later.
 
 ## Why use it?
 

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,6 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "requirements": ["httpx>=0.27.0"],
   "version": "0.3.1"
 }

--- a/tests/test_integration_scaffold.py
+++ b/tests/test_integration_scaffold.py
@@ -10,7 +10,8 @@ def test_manifest_is_hacs_loadable_custom_integration():
     assert manifest["config_flow"] is True
     assert "conversation" in manifest["after_dependencies"]
     assert "ai_task" in manifest["after_dependencies"]
-    assert "httpx" in " ".join(manifest["requirements"])
+    # httpx is provided by Home Assistant core and should not be reinstalled by HACS.
+    assert "requirements" not in manifest
 
 
 def test_integration_declares_conversation_and_ai_task_platform_forwarding():


### PR DESCRIPTION
## Summary

- update the README install path now that Codex Assist is in the default HACS catalog
- replace the custom-repository badge and instructions with default-catalog guidance
- remove `httpx` from the Home Assistant manifest because Home Assistant core provides it
- keep a regression assertion so HACS does not reinstall core-provided dependencies

## Context

HACS reviewer feedback on hacs/default#8205 noted that `httpx` ships with Home Assistant core and that declaring it in `manifest.json` causes unnecessary pip churn.

## Verification

- `uv run ruff check .`
- `uv run pytest -q` — 81 passed
- `uv run --isolated --python 3.14 --with-requirements requirements_test_ha.txt python -m pytest tests_ha -q` — 4 passed
- `git diff --check`
