### PR TITLE
Add opt-in hosted web search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,24 @@ jobs:
       - name: Run smoke tests against real Home Assistant
         run: python -m pytest tests_ha -q
 
+  ha-minimum:
+    name: Home Assistant 2026.5 contract tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install minimum Home Assistant test environment
+        run: pip install -r requirements_test_ha_min.txt
+
+      - name: Run contract tests against minimum Home Assistant
+        run: python -m pytest tests_ha -q
+
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [main]
   schedule:
-    # Weekly run to catch breakage from new Home Assistant releases,
+    # Weekly run to catch regressions in the pinned Home Assistant contracts,
     # hassfest rule changes, and HACS validation changes.
     - cron: "0 6 * * 1"
 
@@ -41,7 +41,7 @@ jobs:
         run: uv run ruff check .
 
   ha-smoke:
-    name: Home Assistant smoke tests
+    name: Home Assistant 2026.8 stable contract tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thanks for helping improve Codex Assist. Bug fixes, documentation improvements, 
 Install [uv](https://docs.astral.sh/uv/) and use the repository-managed environment:
 
 ```bash
-uv sync
+uv sync --all-extras --dev
 uv run ruff check .
 uv run pytest -q
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Codex Assist is included in HACS by default; you do not need to add this GitHub 
 - Let Home Assistant's Assist exposed-entity controls define what the agent can see or control.
 - Ask about exposed entity state and request simple actions in the same Assist chat.
 - Stream replies in Assist while Codex is answering.
-- Configure model, prompt, reasoning effort, reasoning summary, and text verbosity from the integration options flow.
+- Optionally enable hosted web search. Search is off by default; displayed results retain validated source links while spoken responses omit the generated source footer.
+- Configure model, prompt, reasoning effort, reasoning summary, text verbosity, and web search from the integration options flow.
 - Use Home Assistant AI Task for structured data generation, attachment-aware prompts, and subscription-backed image generation with curated image quality and size controls.
 
 <p align="center">
@@ -57,6 +58,8 @@ Codex Assist is included in HACS by default; you do not need to add this GitHub 
 Codex Assist does **not** expose a raw “call any Home Assistant service” bridge. It routes control through Home Assistant's Assist LLM API, so your **Assist exposed entities** list is the practical safety boundary.
 
 Start with harmless lights or read-only questions. Keep locks, alarms, garage doors, water shutoff valves, covers, and other sensitive devices unexposed unless you deliberately want Assist control there.
+
+Hosted web search sends the current model turn to the Codex backend when enabled. Codex Assist does not automatically add Home Assistant state, attachments, location, or tool results to a search request beyond the conversation context already needed for that turn. Structured AI Tasks keep web search disabled so citation text cannot corrupt schema-constrained output.
 
 ## User guide
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,6 +27,8 @@ Codex Assist uses Home Assistant's normal Assist LLM API and exposed-entity cont
 
 The important boundary is: Codex / ChatGPT may request an action, but Codex Assist must route that request through Home Assistant's Assist LLM API. Home Assistant then limits execution to the entities exposed to Assist.
 
+Hosted web search is disabled by default. When enabled, the Codex backend may use the current model turn—including the conversation context already supplied for Assist—to formulate a search. Codex Assist does not add a separate location feed or bypass Home Assistant's exposed-entity boundary. Citation links are accepted only from structured backend annotations and must use validated HTTP(S) URLs before they are displayed.
+
 ## Entity exposure guidance
 
 Only expose entities you intentionally want an Assist conversation agent to read or control.

--- a/custom_components/codex_assist/__init__.py
+++ b/custom_components/codex_assist/__init__.py
@@ -12,6 +12,10 @@ DOMAIN = "codex_assist"
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from homeassistant.const import Platform
 
+    from .codex_runtime import runtime_token_coordinator
+
+    runtime_token_coordinator(entry)
+
     await hass.config_entries.async_forward_entry_setups(
         entry,
         (Platform.CONVERSATION, Platform.AI_TASK),

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -29,9 +29,11 @@ from .codex_client import (
 from .codex_image import DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_SIZE, image_size_dimensions
 from .codex_runtime import runtime_token_coordinator
 from .config_flow import (
+    CONF_WEB_SEARCH,
     DEFAULT_REASONING_EFFORT,
     DEFAULT_REASONING_SUMMARY,
     DEFAULT_TEXT_VERBOSITY,
+    DEFAULT_WEB_SEARCH,
 )
 from .conversation import (
     MAX_TOOL_ITERATIONS,
@@ -98,6 +100,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
         reasoning_effort = settings.get("reasoning_effort", DEFAULT_REASONING_EFFORT)
         reasoning_summary = settings.get("reasoning_summary", DEFAULT_REASONING_SUMMARY)
         text_verbosity = settings.get("text_verbosity", DEFAULT_TEXT_VERBOSITY)
+        web_search = bool(settings.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH))
 
         http_client = get_async_client(self.hass)
         auth_client = CodexAuthClient(http_client=http_client)
@@ -138,6 +141,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
                 text_format=text_format,
+                web_search=web_search,
             )
         except CodexRateLimitError as err:
             LOGGER.warning("Codex Assist AI Task hit usage or rate limit: %s", err)
@@ -235,9 +239,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
             raise HomeAssistantError(f"Codex Assist image generation failed: {err}") from err
         except (ValueError, TypeError) as err:
             LOGGER.exception("Codex Assist AI Task image response handling failed")
-            raise HomeAssistantError(
-                f"Codex Assist image response handling failed: {err}"
-            ) from err
+            raise HomeAssistantError(f"Codex Assist image response handling failed: {err}") from err
 
         chat_log.async_add_assistant_content_without_tools(
             conversation.AssistantContent(
@@ -273,6 +275,7 @@ async def _run_codex_ai_task_chat_log(
     reasoning_summary: str,
     text_verbosity: str,
     text_format: dict[str, Any] | None = None,
+    web_search: bool = False,
 ) -> None:
     """Run Codex over an AI Task chat log with one auth refresh retry."""
     for _iteration in range(MAX_TOOL_ITERATIONS):
@@ -284,7 +287,10 @@ async def _run_codex_ai_task_chat_log(
                 model=model,
                 instructions=_instructions_from_chat_log(chat_log, prompt),
                 input_items=await _codex_input_from_chat_log(hass, chat_log),
-                tools=_codex_tools_from_chat_log(chat_log),
+                tools=_codex_tools_from_chat_log(
+                    chat_log,
+                    enable_web_search=_web_search_enabled(web_search, text_format=text_format),
+                ),
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
@@ -311,7 +317,10 @@ async def _run_codex_ai_task_chat_log(
                     model=model,
                     instructions=_instructions_from_chat_log(chat_log, prompt),
                     input_items=await _codex_input_from_chat_log(hass, chat_log),
-                    tools=_codex_tools_from_chat_log(chat_log),
+                    tools=_codex_tools_from_chat_log(
+                        chat_log,
+                        enable_web_search=_web_search_enabled(web_search, text_format=text_format),
+                    ),
                     reasoning_effort=reasoning_effort,
                     reasoning_summary=reasoning_summary,
                     text_verbosity=text_verbosity,
@@ -372,6 +381,15 @@ async def _generate_codex_ai_task_image(
             ) from retry_err
 
 
+def _web_search_enabled(
+    configured: bool,
+    *,
+    text_format: dict[str, Any] | None,
+) -> bool:
+    """Enable search only when citations cannot corrupt structured output."""
+    return configured and text_format is None
+
+
 def _structured_output_format(
     task: ai_task.GenDataTask,
     chat_log: conversation.ChatLog,
@@ -379,9 +397,7 @@ def _structured_output_format(
     """Convert the Home Assistant AI Task structure to a Responses text format."""
     if not task.structure:
         return None
-    custom_serializer = (
-        chat_log.llm_api.custom_serializer if chat_log.llm_api is not None else None
-    )
+    custom_serializer = chat_log.llm_api.custom_serializer if chat_log.llm_api is not None else None
     return {
         "type": "json_schema",
         "name": _structured_output_name(task.name),

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import voluptuous as vol
 from homeassistant.components import ai_task, conversation
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.httpx_client import get_async_client
+from homeassistant.util import slugify
 from homeassistant.util.json import json_loads
+from voluptuous_openapi import convert
 
 from .codex_auth import (
     CodexAuthClient,
@@ -23,7 +27,7 @@ from .codex_client import (
     CodexRateLimitError,
 )
 from .codex_image import DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_SIZE, image_size_dimensions
-from .codex_runtime import resolve_runtime_tokens
+from .codex_runtime import runtime_token_coordinator
 from .config_flow import (
     DEFAULT_REASONING_EFFORT,
     DEFAULT_REASONING_SUMMARY,
@@ -98,8 +102,8 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
         http_client = get_async_client(self.hass)
         auth_client = CodexAuthClient(http_client=http_client)
         try:
-            tokens = await resolve_runtime_tokens(
-                self.entry.data,
+            tokens = await runtime_token_coordinator(self.entry).resolve(
+                lambda: self.entry.data,
                 auth_client=auth_client,
                 async_update_entry_data=lambda data: self.hass.config_entries.async_update_entry(
                     self.entry,
@@ -119,6 +123,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
 
         codex = CodexClient(http_client=http_client, access_token=tokens.access_token)
         try:
+            text_format = _structured_output_format(task, chat_log)
             await _run_codex_ai_task_chat_log(
                 hass=self.hass,
                 entry=self.entry,
@@ -132,6 +137,7 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
+                text_format=text_format,
             )
         except CodexRateLimitError as err:
             LOGGER.warning("Codex Assist AI Task hit usage or rate limit: %s", err)
@@ -175,8 +181,8 @@ class CodexAssistAITaskEntity(ai_task.AITaskEntity):
         http_client = get_async_client(self.hass)
         auth_client = CodexAuthClient(http_client=http_client)
         try:
-            tokens = await resolve_runtime_tokens(
-                self.entry.data,
+            tokens = await runtime_token_coordinator(self.entry).resolve(
+                lambda: self.entry.data,
                 auth_client=auth_client,
                 async_update_entry_data=lambda data: self.hass.config_entries.async_update_entry(
                     self.entry,
@@ -266,6 +272,7 @@ async def _run_codex_ai_task_chat_log(
     reasoning_effort: str,
     reasoning_summary: str,
     text_verbosity: str,
+    text_format: dict[str, Any] | None = None,
 ) -> None:
     """Run Codex over an AI Task chat log with one auth refresh retry."""
     for _iteration in range(MAX_TOOL_ITERATIONS):
@@ -281,6 +288,7 @@ async def _run_codex_ai_task_chat_log(
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
+                text_format=text_format,
             )
         except CodexAuthenticationError as err:
             LOGGER.warning(
@@ -307,6 +315,7 @@ async def _run_codex_ai_task_chat_log(
                     reasoning_effort=reasoning_effort,
                     reasoning_summary=reasoning_summary,
                     text_verbosity=text_verbosity,
+                    text_format=text_format,
                 )
             except CodexAuthenticationError as retry_err:
                 raise CodexReauthRequiredError(
@@ -363,15 +372,44 @@ async def _generate_codex_ai_task_image(
             ) from retry_err
 
 
-def _structured_data_from_text(text: str, structure: dict[str, Any] | None) -> Any:
-    """Return plain text or parsed JSON for structured AI Task requests."""
+def _structured_output_format(
+    task: ai_task.GenDataTask,
+    chat_log: conversation.ChatLog,
+) -> dict[str, Any] | None:
+    """Convert the Home Assistant AI Task structure to a Responses text format."""
+    if not task.structure:
+        return None
+    custom_serializer = (
+        chat_log.llm_api.custom_serializer if chat_log.llm_api is not None else None
+    )
+    return {
+        "type": "json_schema",
+        "name": _structured_output_name(task.name),
+        "schema": convert(task.structure, custom_serializer=custom_serializer),
+    }
+
+
+def _structured_output_name(name: str) -> str:
+    """Return a nonempty Responses-compatible format name."""
+    normalized = re.sub(r"[^A-Za-z0-9_-]", "_", slugify(name)).strip("_")
+    return normalized[:64] or "structured_output"
+
+
+def _structured_data_from_text(text: str, structure: Any | None) -> Any:
+    """Return plain text or validated structured data for AI Task requests."""
     if not structure:
         return text
     try:
-        return json_loads(text)
+        data = json_loads(text)
     except ValueError as err:
         LOGGER.error(
             "Failed to parse Codex Assist AI Task JSON response (%s chars)",
             len(text),
         )
         raise HomeAssistantError("Codex Assist AI Task returned invalid JSON") from err
+    try:
+        return structure(data)
+    except vol.Invalid as err:
+        raise HomeAssistantError(
+            "Codex Assist AI Task response did not match the requested structure"
+        ) from err

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 from .codex_image import image_model_quality, validate_image_size
 
 CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex"
+CODEX_STREAM_TIMEOUT = 300
 
 
 class AsyncPostClient(Protocol):
@@ -163,6 +164,7 @@ class CodexClient:
             f"{self._base_url}/responses",
             headers=codex_headers(self._access_token),
             json=payload,
+            timeout=CODEX_STREAM_TIMEOUT,
         ) as response:
             if response.status_code != 200:
                 error = await _stream_response_error(response)

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -54,7 +54,20 @@ class CodexToolCallDelta:
     tool_call: CodexToolCall
 
 
-CodexStreamDelta = CodexTextDelta | CodexToolCallDelta
+@dataclass(frozen=True)
+class CodexCitation:
+    title: str
+    url: str
+    start_index: int | None = None
+    end_index: int | None = None
+
+
+@dataclass(frozen=True)
+class CodexCitationDelta:
+    citation: CodexCitation
+
+
+CodexStreamDelta = CodexTextDelta | CodexToolCallDelta | CodexCitationDelta
 
 
 class CodexClient:
@@ -106,9 +119,7 @@ class CodexClient:
         if response.status_code != 200:
             error = _response_error(response)
             if response.status_code == 401 or error.code == "token_invalidated":
-                raise CodexAuthenticationError(
-                    f"Codex authentication failed: {error.detail}"
-                )
+                raise CodexAuthenticationError(f"Codex authentication failed: {error.detail}")
             if _is_rate_limit_response(response.status_code, error):
                 raise CodexRateLimitError(
                     f"Codex usage limit or rate limit reached: {error.detail}"
@@ -156,9 +167,7 @@ class CodexClient:
             if response.status_code != 200:
                 error = await _stream_response_error(response)
                 if response.status_code == 401 or error.code == "token_invalidated":
-                    raise CodexAuthenticationError(
-                        f"Codex authentication failed: {error.detail}"
-                    )
+                    raise CodexAuthenticationError(f"Codex authentication failed: {error.detail}")
                 if _is_rate_limit_response(response.status_code, error):
                     raise CodexRateLimitError(
                         f"Codex usage limit or rate limit reached: {error.detail}"
@@ -172,6 +181,8 @@ class CodexClient:
             completed_tool_call_ids: set[str] = set()
             async for event in _aiter_sse_events(response):
                 event_type = event.get("type")
+                for citation in _citations_from_event(event):
+                    yield CodexCitationDelta(citation)
                 if event_type == "response.output_item.added":
                     item = event.get("item")
                     if isinstance(item, dict) and item.get("type") == "function_call":
@@ -188,9 +199,7 @@ class CodexClient:
                     if isinstance(arguments, str):
                         pending_arguments = arguments
                     if pending_tool_call is not None:
-                        tool_call = _tool_call_from_item(
-                            pending_tool_call, pending_arguments
-                        )
+                        tool_call = _tool_call_from_item(pending_tool_call, pending_arguments)
                         completed_tool_call_ids.add(tool_call.id)
                         yield CodexToolCallDelta(tool_call)
                         pending_tool_call = None
@@ -237,9 +246,7 @@ class CodexClient:
             if response.status_code != 200:
                 error = await _stream_response_error(response)
                 if response.status_code == 401 or error.code == "token_invalidated":
-                    raise CodexAuthenticationError(
-                        f"Codex authentication failed: {error.detail}"
-                    )
+                    raise CodexAuthenticationError(f"Codex authentication failed: {error.detail}")
                 if _is_rate_limit_response(response.status_code, error):
                     raise CodexRateLimitError(
                         f"Codex usage limit or rate limit reached: {error.detail}"
@@ -292,19 +299,24 @@ def _responses_payload(
     }
     if tools:
         payload["tools"] = tools
+    include: list[str] = []
+    if any(tool.get("type") == "web_search" for tool in tools or []):
+        include.append("web_search_call.action.sources")
     text_options: dict[str, Any] = {}
     if _supports_reasoning_options(model):
         if reasoning_effort:
             payload["reasoning"] = {"effort": reasoning_effort}
             if reasoning_summary and reasoning_summary != "off":
                 payload["reasoning"]["summary"] = reasoning_summary
-            payload["include"] = ["reasoning.encrypted_content"]
+            include.insert(0, "reasoning.encrypted_content")
         if text_verbosity:
             text_options["verbosity"] = text_verbosity
     if text_format:
         text_options["format"] = text_format
     if text_options:
         payload["text"] = text_options
+    if include:
+        payload["include"] = include
     return payload
 
 
@@ -351,7 +363,6 @@ def _image_generation_payload(
         },
         "stream": True,
     }
-
 
 
 def _extract_image_b64(value: Any) -> str | None:
@@ -433,9 +444,7 @@ def _chatgpt_account_id(access_token: str) -> str | None:
             return None
         payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
         claims = json.loads(base64.urlsafe_b64decode(payload_b64))
-        account_id = claims.get("https://api.openai.com/auth", {}).get(
-            "chatgpt_account_id"
-        )
+        account_id = claims.get("https://api.openai.com/auth", {}).get("chatgpt_account_id")
     except Exception:
         return None
     return account_id if isinstance(account_id, str) and account_id else None
@@ -513,9 +522,7 @@ def extract_streamed_turn_result(stream_text: str) -> CodexTurnResult:
             item = event.get("item")
             if isinstance(item, dict):
                 if item.get("type") == "function_call":
-                    tool_calls.append(
-                        _tool_call_from_item(item, str(item.get("arguments") or ""))
-                    )
+                    tool_calls.append(_tool_call_from_item(item, str(item.get("arguments") or "")))
                 else:
                     done_parts.append(extract_output_text({"output": [item]}))
 
@@ -626,9 +633,7 @@ def _stream_event_exception(event: dict[str, Any]) -> RuntimeError | None:
     if error.code == "token_invalidated":
         return CodexAuthenticationError(f"Codex authentication failed: {error.detail}")
     if _is_rate_limit_response(200, error):
-        return CodexRateLimitError(
-            f"Codex usage limit or rate limit reached: {error.detail}"
-        )
+        return CodexRateLimitError(f"Codex usage limit or rate limit reached: {error.detail}")
     return RuntimeError(f"Codex stream failed: {error.detail}")
 
 
@@ -673,6 +678,42 @@ def _tool_call_from_item(item: dict[str, Any], arguments: str) -> CodexToolCall:
         arguments=parsed_arguments,
     )
 
+
+def _citation_from_annotation(annotation: Any) -> CodexCitation | None:
+    if not isinstance(annotation, dict) or annotation.get("type") != "url_citation":
+        return None
+    title = annotation.get("title")
+    url = annotation.get("url")
+    if not isinstance(title, str) or not title.strip():
+        return None
+    if not isinstance(url, str) or not url.strip():
+        return None
+    start_index = annotation.get("start_index")
+    end_index = annotation.get("end_index")
+    return CodexCitation(
+        title=title.strip(),
+        url=url.strip(),
+        start_index=start_index if isinstance(start_index, int) else None,
+        end_index=end_index if isinstance(end_index, int) else None,
+    )
+
+
+def _citations_from_event(event: dict[str, Any]) -> list[CodexCitation]:
+    annotations: list[Any] = []
+    if event.get("type") == "response.output_text.annotation.added":
+        annotations.append(event.get("annotation"))
+
+    item = event.get("item")
+    if isinstance(item, dict):
+        for content in item.get("content") or []:
+            if isinstance(content, dict):
+                annotations.extend(content.get("annotations") or [])
+
+    return [
+        citation
+        for annotation in annotations
+        if (citation := _citation_from_annotation(annotation)) is not None
+    ]
 
 
 async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -67,7 +67,17 @@ class CodexCitationDelta:
     citation: CodexCitation
 
 
-CodexStreamDelta = CodexTextDelta | CodexToolCallDelta | CodexCitationDelta
+@dataclass(frozen=True)
+class CodexWebSearchStartedDelta:
+    """Signal that the hosted web-search tool has started work."""
+
+
+CodexStreamDelta = (
+    CodexTextDelta
+    | CodexToolCallDelta
+    | CodexCitationDelta
+    | CodexWebSearchStartedDelta
+)
 
 
 class CodexClient:
@@ -179,10 +189,14 @@ class CodexClient:
             pending_tool_call: dict[str, Any] | None = None
             pending_arguments = ""
             completed_tool_call_ids: set[str] = set()
+            web_search_started = False
             async for event in _aiter_sse_events(response):
                 event_type = event.get("type")
                 for citation in _citations_from_event(event):
                     yield CodexCitationDelta(citation)
+                if not web_search_started and _is_web_search_started_event(event):
+                    web_search_started = True
+                    yield CodexWebSearchStartedDelta()
                 if event_type == "response.output_item.added":
                     item = event.get("item")
                     if isinstance(item, dict) and item.get("type") == "function_call":
@@ -714,6 +728,21 @@ def _citations_from_event(event: dict[str, Any]) -> list[CodexCitation]:
         for annotation in annotations
         if (citation := _citation_from_annotation(annotation)) is not None
     ]
+
+
+def _is_web_search_started_event(event: dict[str, Any]) -> bool:
+    event_type = event.get("type")
+    if event_type in {
+        "response.web_search_call.in_progress",
+        "response.web_search_call.searching",
+    }:
+        return True
+    item = event.get("item")
+    return (
+        event_type == "response.output_item.added"
+        and isinstance(item, dict)
+        and item.get("type") == "web_search_call"
+    )
 
 
 async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -67,17 +67,7 @@ class CodexCitationDelta:
     citation: CodexCitation
 
 
-@dataclass(frozen=True)
-class CodexWebSearchStartedDelta:
-    """Signal that the hosted web-search tool has started work."""
-
-
-CodexStreamDelta = (
-    CodexTextDelta
-    | CodexToolCallDelta
-    | CodexCitationDelta
-    | CodexWebSearchStartedDelta
-)
+CodexStreamDelta = CodexTextDelta | CodexToolCallDelta | CodexCitationDelta
 
 
 class CodexClient:
@@ -189,14 +179,10 @@ class CodexClient:
             pending_tool_call: dict[str, Any] | None = None
             pending_arguments = ""
             completed_tool_call_ids: set[str] = set()
-            web_search_started = False
             async for event in _aiter_sse_events(response):
                 event_type = event.get("type")
                 for citation in _citations_from_event(event):
                     yield CodexCitationDelta(citation)
-                if not web_search_started and _is_web_search_started_event(event):
-                    web_search_started = True
-                    yield CodexWebSearchStartedDelta()
                 if event_type == "response.output_item.added":
                     item = event.get("item")
                     if isinstance(item, dict) and item.get("type") == "function_call":
@@ -728,21 +714,6 @@ def _citations_from_event(event: dict[str, Any]) -> list[CodexCitation]:
         for annotation in annotations
         if (citation := _citation_from_annotation(annotation)) is not None
     ]
-
-
-def _is_web_search_started_event(event: dict[str, Any]) -> bool:
-    event_type = event.get("type")
-    if event_type in {
-        "response.web_search_call.in_progress",
-        "response.web_search_call.searching",
-    }:
-        return True
-    item = event.get("item")
-    return (
-        event_type == "response.output_item.added"
-        and isinstance(item, dict)
-        and item.get("type") == "web_search_call"
-    )
 
 
 async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -134,6 +134,7 @@ class CodexClient:
         reasoning_effort: str | None = None,
         reasoning_summary: str | None = None,
         text_verbosity: str | None = None,
+        text_format: dict[str, Any] | None = None,
     ) -> AsyncIterator[CodexStreamDelta]:
         payload = _responses_payload(
             model=model,
@@ -143,6 +144,7 @@ class CodexClient:
             reasoning_effort=reasoning_effort,
             reasoning_summary=reasoning_summary,
             text_verbosity=text_verbosity,
+            text_format=text_format,
         )
 
         async with self._http_client.stream(
@@ -279,6 +281,7 @@ def _responses_payload(
     reasoning_effort: str | None = None,
     reasoning_summary: str | None = None,
     text_verbosity: str | None = None,
+    text_format: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "model": model,
@@ -289,6 +292,7 @@ def _responses_payload(
     }
     if tools:
         payload["tools"] = tools
+    text_options: dict[str, Any] = {}
     if _supports_reasoning_options(model):
         if reasoning_effort:
             payload["reasoning"] = {"effort": reasoning_effort}
@@ -296,7 +300,11 @@ def _responses_payload(
                 payload["reasoning"]["summary"] = reasoning_summary
             payload["include"] = ["reasoning.encrypted_content"]
         if text_verbosity:
-            payload["text"] = {"verbosity": text_verbosity}
+            text_options["verbosity"] = text_verbosity
+    if text_format:
+        text_options["format"] = text_format
+    if text_options:
+        payload["text"] = text_options
     return payload
 
 
@@ -474,8 +482,8 @@ def extract_streamed_turn_result(stream_text: str) -> CodexTurnResult:
 
     for event in _iter_sse_events(stream_text):
         event_type = event.get("type")
-        if event_type == "error":
-            raise RuntimeError(_event_error_detail(event))
+        if stream_error := _stream_event_exception(event):
+            raise stream_error
         if event_type == "response.output_text.delta":
             delta = event.get("delta")
             if isinstance(delta, str):
@@ -588,6 +596,42 @@ def _event_error_detail(event: dict[str, Any]) -> str:
     return "Codex stream returned an error event"
 
 
+def _stream_event_exception(event: dict[str, Any]) -> RuntimeError | None:
+    event_type = event.get("type")
+    if event_type == "error":
+        return RuntimeError(_event_error_detail(event))
+    if event_type == "response.incomplete":
+        response = event.get("response")
+        details = response.get("incomplete_details") if isinstance(response, dict) else None
+        reason = details.get("reason") if isinstance(details, dict) else None
+        reason_text = reason if isinstance(reason, str) and reason else "unknown reason"
+        return RuntimeError(f"Codex response incomplete: {reason_text}")
+    if event_type != "response.failed":
+        return None
+
+    response = event.get("response")
+    error_value = response.get("error") if isinstance(response, dict) else None
+    if isinstance(error_value, dict):
+        code_value = error_value.get("code")
+        message_value = error_value.get("message") or error_value.get("detail") or code_value
+        error = CodexResponseError(
+            message_value if isinstance(message_value, str) else "unknown error",
+            code_value if isinstance(code_value, str) else None,
+        )
+    elif isinstance(error_value, str):
+        error = CodexResponseError(error_value)
+    else:
+        error = CodexResponseError("response.failed event received")
+
+    if error.code == "token_invalidated":
+        return CodexAuthenticationError(f"Codex authentication failed: {error.detail}")
+    if _is_rate_limit_response(200, error):
+        return CodexRateLimitError(
+            f"Codex usage limit or rate limit reached: {error.detail}"
+        )
+    return RuntimeError(f"Codex stream failed: {error.detail}")
+
+
 def extract_output_text(payload: dict[str, Any]) -> str:
     parts: list[str] = []
     for item in payload.get("output") or []:
@@ -672,8 +716,8 @@ def _parse_sse_payload(
 
 def _stream_delta_from_event(event: dict[str, Any]) -> CodexStreamDelta | None:
     event_type = event.get("type")
-    if event_type == "error":
-        raise RuntimeError(_event_error_detail(event))
+    if stream_error := _stream_event_exception(event):
+        raise stream_error
     if event_type == "response.output_text.delta":
         delta = event.get("delta")
         return CodexTextDelta(delta) if isinstance(delta, str) and delta else None

--- a/custom_components/codex_assist/codex_runtime.py
+++ b/custom_components/codex_assist/codex_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import inspect
 import json
@@ -16,20 +17,79 @@ class RuntimeAuthClient(Protocol):
     async def refresh(self, tokens: CodexTokenSet) -> CodexTokenSet: ...
 
 
+class RuntimeTokenCoordinator:
+    """Serialize rotating-token refreshes for one config entry."""
+
+    def __init__(self) -> None:
+        self._refresh_lock = asyncio.Lock()
+
+    async def resolve(
+        self,
+        get_entry_data: Callable[[], Mapping[str, Any]],
+        *,
+        auth_client: RuntimeAuthClient,
+        async_update_entry_data: Callable[[dict[str, Any]], Awaitable[None] | None],
+        now: float | None = None,
+        refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
+    ) -> CodexTokenSet:
+        """Resolve current credentials, refreshing once under the entry lock."""
+        async with self._refresh_lock:
+            return await resolve_runtime_tokens(
+                get_entry_data(),
+                auth_client=auth_client,
+                async_update_entry_data=async_update_entry_data,
+                get_current_entry_data=get_entry_data,
+                now=now,
+                refresh_skew_seconds=refresh_skew_seconds,
+            )
+
+    async def refresh_after_rejection(
+        self,
+        get_entry_data: Callable[[], Mapping[str, Any]],
+        *,
+        rejected_tokens: CodexTokenSet,
+        auth_client: RuntimeAuthClient,
+        async_update_entry_data: Callable[[dict[str, Any]], Awaitable[None] | None],
+    ) -> CodexTokenSet:
+        """Refresh a rejected token or reuse credentials rotated by another request."""
+        async with self._refresh_lock:
+            entry_data = get_entry_data()
+            current = _tokens_from_entry_data(entry_data)
+            if current != rejected_tokens:
+                return current
+            if not current.refresh_token:
+                raise CodexReauthRequiredError("Codex Assist is missing refresh_token")
+            refreshed = await auth_client.refresh(current)
+            latest_data = get_entry_data()
+            latest = _tokens_from_entry_data(latest_data)
+            if latest != current:
+                return latest
+            await _persist_runtime_tokens(latest_data, refreshed, async_update_entry_data)
+            return refreshed
+
+
+def runtime_token_coordinator(entry: Any) -> RuntimeTokenCoordinator:
+    """Return the coordinator shared by all platforms for a config entry."""
+    coordinator = getattr(entry, "runtime_data", None)
+    if isinstance(coordinator, RuntimeTokenCoordinator):
+        return coordinator
+    coordinator = RuntimeTokenCoordinator()
+    entry.runtime_data = coordinator
+    return coordinator
+
+
 async def resolve_runtime_tokens(
     entry_data: Mapping[str, Any],
     *,
     auth_client: RuntimeAuthClient,
     async_update_entry_data: Callable[[dict[str, Any]], Awaitable[None] | None],
+    get_current_entry_data: Callable[[], Mapping[str, Any]] | None = None,
     now: float | None = None,
     refresh_skew_seconds: int = ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
 ) -> CodexTokenSet:
-    access_token = str(entry_data.get("access_token") or "").strip()
-    refresh_token = str(entry_data.get("refresh_token") or "").strip()
-    if not access_token:
-        raise CodexReauthRequiredError("Codex Assist is missing access_token")
-
-    tokens = CodexTokenSet(access_token=access_token, refresh_token=refresh_token)
+    tokens = _tokens_from_entry_data(entry_data)
+    access_token = tokens.access_token
+    refresh_token = tokens.refresh_token
     now = time.time() if now is None else now
     exp = _decode_jwt_exp(access_token)
     if exp is None or exp > now + refresh_skew_seconds:
@@ -45,13 +105,33 @@ async def resolve_runtime_tokens(
             return tokens
         raise
 
+    latest_data = get_current_entry_data() if get_current_entry_data else entry_data
+    latest = _tokens_from_entry_data(latest_data)
+    if latest != tokens:
+        return latest
+    await _persist_runtime_tokens(latest_data, refreshed, async_update_entry_data)
+    return refreshed
+
+
+def _tokens_from_entry_data(entry_data: Mapping[str, Any]) -> CodexTokenSet:
+    access_token = str(entry_data.get("access_token") or "").strip()
+    refresh_token = str(entry_data.get("refresh_token") or "").strip()
+    if not access_token:
+        raise CodexReauthRequiredError("Codex Assist is missing access_token")
+    return CodexTokenSet(access_token=access_token, refresh_token=refresh_token)
+
+
+async def _persist_runtime_tokens(
+    entry_data: Mapping[str, Any],
+    tokens: CodexTokenSet,
+    async_update_entry_data: Callable[[dict[str, Any]], Awaitable[None] | None],
+) -> None:
     updated_data = dict(entry_data)
-    updated_data["access_token"] = refreshed.access_token
-    updated_data["refresh_token"] = refreshed.refresh_token
+    updated_data["access_token"] = tokens.access_token
+    updated_data["refresh_token"] = tokens.refresh_token
     result = async_update_entry_data(updated_data)
     if inspect.isawaitable(result):
         await result
-    return refreshed
 
 
 def access_token_is_expiring(

--- a/custom_components/codex_assist/config_flow.py
+++ b/custom_components/codex_assist/config_flow.py
@@ -31,11 +31,13 @@ CONF_IMAGE_SIZE = "image_size"
 CONF_REASONING_EFFORT = "reasoning_effort"
 CONF_REASONING_SUMMARY = "reasoning_summary"
 CONF_TEXT_VERBOSITY = "text_verbosity"
+CONF_WEB_SEARCH = "web_search"
 DEFAULT_MODEL = "gpt-5.4"
 DEFAULT_PROMPT = "You are a concise Home Assistant Assist conversation agent."
 DEFAULT_REASONING_EFFORT = "low"
 DEFAULT_REASONING_SUMMARY = "auto"
 DEFAULT_TEXT_VERBOSITY = "medium"
+DEFAULT_WEB_SEARCH = False
 
 
 class CodexAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -141,6 +143,7 @@ class CodexAssistConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_REASONING_EFFORT,
                 CONF_REASONING_SUMMARY,
                 CONF_TEXT_VERBOSITY,
+                CONF_WEB_SEARCH,
             )
             if key in entry_data
         }
@@ -245,6 +248,10 @@ def _settings_schema(
                     mode=selector.SelectSelectorMode.DROPDOWN,
                 )
             ),
+            vol.Optional(
+                CONF_WEB_SEARCH,
+                default=defaults.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH),
+            ): bool,
             vol.Optional(
                 CONF_IMAGE_MODEL,
                 default=image_model_default,

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -32,7 +32,6 @@ from .codex_client import (
     CodexStreamDelta,
     CodexTextDelta,
     CodexToolCallDelta,
-    CodexWebSearchStartedDelta,
     codex_user_content_with_images,
 )
 from .codex_runtime import runtime_token_coordinator
@@ -50,13 +49,6 @@ MAX_IMAGE_ATTACHMENTS = 4
 MAX_TOTAL_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
 _SOURCES_SEPARATOR = "\n\nSources:\n"
-# Home Assistant starts streaming TTS after more than 60 assistant characters.
-# A hosted search can otherwise leave the already-open audio request idle until
-# a reverse proxy or browser gives up before the first audio byte arrives.
-_WEB_SEARCH_TTS_ACKNOWLEDGEMENT = (
-    "I’m checking current sources now. This may take a few seconds while I verify "
-    "the latest information. "
-)
 
 
 async def async_setup_entry(
@@ -327,8 +319,6 @@ async def _codex_stream_to_assistant_deltas(
             started = True
         if isinstance(delta, CodexTextDelta):
             yield {"content": delta.text}
-        elif isinstance(delta, CodexWebSearchStartedDelta):
-            yield {"content": _WEB_SEARCH_TTS_ACKNOWLEDGEMENT}
         elif isinstance(delta, CodexToolCallDelta):
             if on_tool_call is not None:
                 on_tool_call()

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -4,6 +4,7 @@ import json
 import logging
 from collections.abc import AsyncIterator, Callable
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
 from homeassistant.components import conversation
@@ -24,6 +25,8 @@ from .codex_auth import (
 )
 from .codex_client import (
     CodexAuthenticationError,
+    CodexCitation,
+    CodexCitationDelta,
     CodexClient,
     CodexRateLimitError,
     CodexStreamDelta,
@@ -33,9 +36,11 @@ from .codex_client import (
 )
 from .codex_runtime import runtime_token_coordinator
 from .config_flow import (
+    CONF_WEB_SEARCH,
     DEFAULT_REASONING_EFFORT,
     DEFAULT_REASONING_SUMMARY,
     DEFAULT_TEXT_VERBOSITY,
+    DEFAULT_WEB_SEARCH,
 )
 
 MAX_TOOL_ITERATIONS = 5
@@ -43,6 +48,7 @@ MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024
 MAX_IMAGE_ATTACHMENTS = 4
 MAX_TOTAL_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
+_SOURCES_SEPARATOR = "\n\nSources:\n"
 
 
 async def async_setup_entry(
@@ -92,6 +98,9 @@ class CodexAssistConversationEntity(
         reasoning_effort = settings.get("reasoning_effort", DEFAULT_REASONING_EFFORT)
         reasoning_summary = settings.get("reasoning_summary", DEFAULT_REASONING_SUMMARY)
         text_verbosity = settings.get("text_verbosity", DEFAULT_TEXT_VERBOSITY)
+        web_search = bool(settings.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH))
+        citations: list[CodexCitation] = []
+        citation_footers: list[str] = []
 
         response = intent.IntentResponse(language=user_input.language)
         try:
@@ -139,10 +148,12 @@ class CodexAssistConversationEntity(
                         model=model,
                         instructions=_instructions_from_chat_log(chat_log, prompt),
                         input_items=await _codex_input_from_chat_log(self.hass, chat_log),
-                        tools=_codex_tools_from_chat_log(chat_log),
+                        tools=_codex_tools_from_chat_log(chat_log, enable_web_search=web_search),
                         reasoning_effort=reasoning_effort,
                         reasoning_summary=reasoning_summary,
                         text_verbosity=text_verbosity,
+                        citation_sink=citations,
+                        citation_footer_sink=citation_footers,
                     )
                 except CodexAuthenticationError as err:
                     LOGGER.warning(
@@ -179,10 +190,14 @@ class CodexAssistConversationEntity(
                             model=model,
                             instructions=_instructions_from_chat_log(chat_log, prompt),
                             input_items=await _codex_input_from_chat_log(self.hass, chat_log),
-                            tools=_codex_tools_from_chat_log(chat_log),
+                            tools=_codex_tools_from_chat_log(
+                                chat_log, enable_web_search=web_search
+                            ),
                             reasoning_effort=reasoning_effort,
                             reasoning_summary=reasoning_summary,
                             text_verbosity=text_verbosity,
+                            citation_sink=citations,
+                            citation_footer_sink=citation_footers,
                         )
                     except CodexAuthenticationError as retry_err:
                         LOGGER.warning(
@@ -229,7 +244,9 @@ class CodexAssistConversationEntity(
                 )
             )
 
-        return conversation.async_get_result_from_chat_log(user_input, chat_log)
+        result = conversation.async_get_result_from_chat_log(user_input, chat_log)
+        _separate_citations_from_result_speech(result, citations, citation_footers)
+        return result
 
 
 async def _stream_codex_turn_into_chat_log(
@@ -245,6 +262,8 @@ async def _stream_codex_turn_into_chat_log(
     reasoning_summary: str,
     text_verbosity: str,
     text_format: dict[str, Any] | None = None,
+    citation_sink: list[CodexCitation] | None = None,
+    citation_footer_sink: list[str] | None = None,
 ) -> bool:
     tool_call_requested = False
 
@@ -266,6 +285,8 @@ async def _stream_codex_turn_into_chat_log(
                 text_format=text_format,
             ),
             on_tool_call=mark_tool_call_requested,
+            citation_sink=citation_sink,
+            citation_footer_sink=citation_footer_sink,
         ),
     ):
         pass
@@ -276,9 +297,23 @@ async def _codex_stream_to_assistant_deltas(
     stream: AsyncIterator[CodexStreamDelta],
     *,
     on_tool_call: Callable[[], None] | None = None,
+    citation_sink: list[CodexCitation] | None = None,
+    citation_footer_sink: list[str] | None = None,
 ) -> AsyncIterator[AssistantContentDeltaDict]:
     started = False
+    citations: list[CodexCitation] = []
+    seen_urls: set[str] = set()
     async for delta in stream:
+        if isinstance(delta, CodexCitationDelta):
+            citation = _safe_citation(delta.citation)
+            if citation is not None and citation.url not in seen_urls:
+                seen_urls.add(citation.url)
+                citations.append(citation)
+                if citation_sink is not None and all(
+                    existing.url != citation.url for existing in citation_sink
+                ):
+                    citation_sink.append(citation)
+            continue
         if not started:
             yield {"role": "assistant"}
             started = True
@@ -296,6 +331,71 @@ async def _codex_stream_to_assistant_deltas(
                     )
                 ]
             }
+    if citations:
+        if not started:
+            yield {"role": "assistant"}
+        footer = _citation_footer(citations)
+        if citation_footer_sink is not None:
+            citation_footer_sink.append(footer)
+        yield {"content": footer}
+
+
+def _safe_citation(citation: CodexCitation) -> CodexCitation | None:
+    if len(citation.url) > 2048:
+        return None
+    if any(character.isspace() or ord(character) < 32 for character in citation.url):
+        return None
+    try:
+        parsed = urlsplit(citation.url)
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    if "<" in citation.url or ">" in citation.url:
+        return None
+    title = " ".join(citation.title.split())[:200]
+    if not title:
+        return None
+    title = (
+        title.replace("\\", "\\\\")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+    return CodexCitation(
+        title=title,
+        url=citation.url,
+        start_index=citation.start_index,
+        end_index=citation.end_index,
+    )
+
+
+def _citation_lines(citations: list[CodexCitation]) -> str:
+    return "\n".join(f"- {citation.title} — <{citation.url}>" for citation in citations)
+
+
+def _citation_footer(citations: list[CodexCitation]) -> str:
+    return f"{_SOURCES_SEPARATOR}{_citation_lines(citations)}"
+
+
+def _separate_citations_from_result_speech(
+    result: conversation.ConversationResult,
+    citations: list[CodexCitation],
+    citation_footers: list[str],
+) -> None:
+    if not citations:
+        return
+    response = result.response
+    speech = getattr(response, "speech", None)
+    if isinstance(speech, dict):
+        plain = speech.get("plain")
+        if isinstance(plain, dict) and isinstance(plain.get("speech"), str):
+            for footer in reversed(citation_footers):
+                if plain["speech"].endswith(footer):
+                    plain["speech"] = plain["speech"].removesuffix(footer).rstrip()
+                    break
+    response.async_set_card("Sources", _citation_lines(citations))
 
 
 async def _refresh_runtime_tokens(
@@ -406,8 +506,7 @@ def _trim_codex_input_items(
     return [
         item
         for item in trimmed
-        if item.get("type") != "function_call_output"
-        or str(item.get("call_id")) in included_calls
+        if item.get("type") != "function_call_output" or str(item.get("call_id")) in included_calls
     ]
 
 
@@ -444,9 +543,7 @@ def _image_attachments_for_codex(attachments: Any) -> list[tuple[str, bytes]]:
         candidates.append((mime_type, path, size))
 
     if len(candidates) > MAX_IMAGE_ATTACHMENTS:
-        raise ValueError(
-            f"Codex Assist accepts at most {MAX_IMAGE_ATTACHMENTS} image attachments"
-        )
+        raise ValueError(f"Codex Assist accepts at most {MAX_IMAGE_ATTACHMENTS} image attachments")
     if sum(size for _, _, size in candidates) > MAX_TOTAL_IMAGE_ATTACHMENT_BYTES:
         raise ValueError("Codex Assist image attachments exceed the total attachment size limit")
 
@@ -472,14 +569,20 @@ def _image_attachments_for_codex(attachments: Any) -> list[tuple[str, bytes]]:
     return images
 
 
-def _codex_tools_from_chat_log(chat_log: conversation.ChatLog) -> list[dict[str, Any]]:
-    if not chat_log.llm_api:
-        return []
-
-    return [
-        _codex_tool_from_ha_tool(tool, chat_log.llm_api.custom_serializer)
-        for tool in chat_log.llm_api.tools
-    ]
+def _codex_tools_from_chat_log(
+    chat_log: conversation.ChatLog,
+    *,
+    enable_web_search: bool = False,
+) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    if chat_log.llm_api:
+        tools.extend(
+            _codex_tool_from_ha_tool(tool, chat_log.llm_api.custom_serializer)
+            for tool in chat_log.llm_api.tools
+        )
+    if enable_web_search:
+        tools.append({"type": "web_search"})
+    return tools
 
 
 def _codex_tool_from_ha_tool(

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -31,7 +31,7 @@ from .codex_client import (
     CodexToolCallDelta,
     codex_user_content_with_images,
 )
-from .codex_runtime import resolve_runtime_tokens
+from .codex_runtime import runtime_token_coordinator
 from .config_flow import (
     DEFAULT_REASONING_EFFORT,
     DEFAULT_REASONING_SUMMARY,
@@ -40,6 +40,8 @@ from .config_flow import (
 
 MAX_TOOL_ITERATIONS = 5
 MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024
+MAX_IMAGE_ATTACHMENTS = 4
+MAX_TOTAL_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
 
 
@@ -105,8 +107,8 @@ class CodexAssistConversationEntity(
         http_client = get_async_client(self.hass)
         auth_client = CodexAuthClient(http_client=http_client)
         try:
-            tokens = await resolve_runtime_tokens(
-                self.entry.data,
+            tokens = await runtime_token_coordinator(self.entry).resolve(
+                lambda: self.entry.data,
                 auth_client=auth_client,
                 async_update_entry_data=lambda data: self.hass.config_entries.async_update_entry(
                     self.entry,
@@ -242,6 +244,7 @@ async def _stream_codex_turn_into_chat_log(
     reasoning_effort: str,
     reasoning_summary: str,
     text_verbosity: str,
+    text_format: dict[str, Any] | None = None,
 ) -> bool:
     tool_call_requested = False
 
@@ -260,6 +263,7 @@ async def _stream_codex_turn_into_chat_log(
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
                 text_verbosity=text_verbosity,
+                text_format=text_format,
             ),
             on_tool_call=mark_tool_call_requested,
         ),
@@ -300,14 +304,15 @@ async def _refresh_runtime_tokens(
     auth_client: CodexAuthClient,
     tokens: CodexTokenSet,
 ) -> CodexTokenSet:
-    if not tokens.refresh_token:
-        raise CodexReauthRequiredError("Codex Assist is missing refresh_token")
-    refreshed = await auth_client.refresh(tokens)
-    updated_data = dict(entry.data)
-    updated_data["access_token"] = refreshed.access_token
-    updated_data["refresh_token"] = refreshed.refresh_token
-    hass.config_entries.async_update_entry(entry, data=updated_data)
-    return refreshed
+    return await runtime_token_coordinator(entry).refresh_after_rejection(
+        lambda: entry.data,
+        rejected_tokens=tokens,
+        auth_client=auth_client,
+        async_update_entry_data=lambda data: hass.config_entries.async_update_entry(
+            entry,
+            data=data,
+        ),
+    )
 
 
 def _start_reauth_result(
@@ -416,7 +421,7 @@ async def _async_image_attachments_for_codex(
 
 
 def _image_attachments_for_codex(attachments: Any) -> list[tuple[str, bytes]]:
-    images: list[tuple[str, bytes]] = []
+    candidates: list[tuple[str, Any, int]] = []
     for attachment in attachments:
         mime_type = getattr(attachment, "mime_type", "")
         if not isinstance(mime_type, str) or not mime_type.startswith("image/"):
@@ -425,16 +430,45 @@ def _image_attachments_for_codex(attachments: Any) -> list[tuple[str, bytes]]:
         if path is None:
             continue
         try:
-            if path.stat().st_size > MAX_IMAGE_ATTACHMENT_BYTES:
-                LOGGER.warning(
-                    "Skipping Codex Assist image attachment over %s bytes: %s",
-                    MAX_IMAGE_ATTACHMENT_BYTES,
-                    path,
-                )
-                continue
-            images.append((mime_type, path.read_bytes()))
+            size = path.stat().st_size
         except OSError as err:
             LOGGER.warning("Skipping unreadable Codex Assist image attachment %s: %s", path, err)
+            continue
+        if size > MAX_IMAGE_ATTACHMENT_BYTES:
+            LOGGER.warning(
+                "Skipping Codex Assist image attachment over %s bytes: %s",
+                MAX_IMAGE_ATTACHMENT_BYTES,
+                path,
+            )
+            continue
+        candidates.append((mime_type, path, size))
+
+    if len(candidates) > MAX_IMAGE_ATTACHMENTS:
+        raise ValueError(
+            f"Codex Assist accepts at most {MAX_IMAGE_ATTACHMENTS} image attachments"
+        )
+    if sum(size for _, _, size in candidates) > MAX_TOTAL_IMAGE_ATTACHMENT_BYTES:
+        raise ValueError("Codex Assist image attachments exceed the total attachment size limit")
+
+    images: list[tuple[str, bytes]] = []
+    total_bytes = 0
+    for mime_type, path, _size in candidates:
+        remaining_bytes = MAX_TOTAL_IMAGE_ATTACHMENT_BYTES - total_bytes
+        read_limit = min(MAX_IMAGE_ATTACHMENT_BYTES, remaining_bytes)
+        try:
+            with path.open("rb") as attachment_file:
+                data = attachment_file.read(read_limit + 1)
+        except OSError as err:
+            LOGGER.warning("Skipping unreadable Codex Assist image attachment %s: %s", path, err)
+            continue
+        if len(data) > MAX_IMAGE_ATTACHMENT_BYTES:
+            raise ValueError("Codex Assist image attachment grew beyond the per-file size limit")
+        if len(data) > remaining_bytes:
+            raise ValueError(
+                "Codex Assist image attachments exceed the total attachment size limit"
+            )
+        total_bytes += len(data)
+        images.append((mime_type, data))
     return images
 
 

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -32,6 +32,7 @@ from .codex_client import (
     CodexStreamDelta,
     CodexTextDelta,
     CodexToolCallDelta,
+    CodexWebSearchStartedDelta,
     codex_user_content_with_images,
 )
 from .codex_runtime import runtime_token_coordinator
@@ -49,6 +50,13 @@ MAX_IMAGE_ATTACHMENTS = 4
 MAX_TOTAL_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
 _SOURCES_SEPARATOR = "\n\nSources:\n"
+# Home Assistant starts streaming TTS after more than 60 assistant characters.
+# A hosted search can otherwise leave the already-open audio request idle until
+# a reverse proxy or browser gives up before the first audio byte arrives.
+_WEB_SEARCH_TTS_ACKNOWLEDGEMENT = (
+    "I’m checking current sources now. This may take a few seconds while I verify "
+    "the latest information. "
+)
 
 
 async def async_setup_entry(
@@ -319,6 +327,8 @@ async def _codex_stream_to_assistant_deltas(
             started = True
         if isinstance(delta, CodexTextDelta):
             yield {"content": delta.text}
+        elif isinstance(delta, CodexWebSearchStartedDelta):
+            yield {"content": _WEB_SEARCH_TTS_ACKNOWLEDGEMENT}
         elif isinstance(delta, CodexToolCallDelta):
             if on_tool_call is not None:
                 on_tool_call()

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -132,7 +132,7 @@ class CodexAssistConversationEntity(
             chat_log.async_add_assistant_content_without_tools(
                 conversation.AssistantContent(
                     agent_id=user_input.agent_id,
-                    content=f"Codex Assist failed: {err}",
+                    content=_request_failure_text(err),
                 )
             )
             return conversation.async_get_result_from_chat_log(user_input, chat_log)
@@ -227,7 +227,7 @@ class CodexAssistConversationEntity(
             )
         except (httpx.HTTPError, RuntimeError) as err:
             LOGGER.exception("Codex Assist model request failed")
-            text = f"Codex Assist failed: {err}"
+            text = _request_failure_text(err)
             chat_log.async_add_assistant_content_without_tools(
                 conversation.AssistantContent(
                     agent_id=user_input.agent_id,
@@ -247,6 +247,12 @@ class CodexAssistConversationEntity(
         result = conversation.async_get_result_from_chat_log(user_input, chat_log)
         _separate_citations_from_result_speech(result, citations, citation_footers)
         return result
+
+
+def _request_failure_text(err: BaseException) -> str:
+    """Return a useful user-facing failure even for blank transport errors."""
+    detail = str(err).strip() or type(err).__name__
+    return f"Codex Assist failed: {detail}"
 
 
 async def _stream_codex_turn_into_chat_log(

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -48,7 +48,11 @@ MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024
 MAX_IMAGE_ATTACHMENTS = 4
 MAX_TOTAL_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
-_SOURCES_SEPARATOR = "\n\nSources:\n"
+_WEB_SEARCH_CITATION_INSTRUCTIONS = (
+    "When using web search, do not include raw URLs, markdown links, or a Source/Sources "
+    "section in the response text. Refer to sources by human-readable names only. The "
+    "integration renders structured citations separately."
+)
 
 
 async def async_setup_entry(
@@ -100,7 +104,6 @@ class CodexAssistConversationEntity(
         text_verbosity = settings.get("text_verbosity", DEFAULT_TEXT_VERBOSITY)
         web_search = bool(settings.get(CONF_WEB_SEARCH, DEFAULT_WEB_SEARCH))
         citations: list[CodexCitation] = []
-        citation_footers: list[str] = []
 
         response = intent.IntentResponse(language=user_input.language)
         try:
@@ -146,14 +149,15 @@ class CodexAssistConversationEntity(
                         codex=codex,
                         entity_id=self.entity_id or "",
                         model=model,
-                        instructions=_instructions_from_chat_log(chat_log, prompt),
+                        instructions=_instructions_for_turn(
+                            chat_log, prompt, web_search=web_search
+                        ),
                         input_items=await _codex_input_from_chat_log(self.hass, chat_log),
                         tools=_codex_tools_from_chat_log(chat_log, enable_web_search=web_search),
                         reasoning_effort=reasoning_effort,
                         reasoning_summary=reasoning_summary,
                         text_verbosity=text_verbosity,
                         citation_sink=citations,
-                        citation_footer_sink=citation_footers,
                     )
                 except CodexAuthenticationError as err:
                     LOGGER.warning(
@@ -188,7 +192,9 @@ class CodexAssistConversationEntity(
                             codex=codex,
                             entity_id=self.entity_id or "",
                             model=model,
-                            instructions=_instructions_from_chat_log(chat_log, prompt),
+                            instructions=_instructions_for_turn(
+                                chat_log, prompt, web_search=web_search
+                            ),
                             input_items=await _codex_input_from_chat_log(self.hass, chat_log),
                             tools=_codex_tools_from_chat_log(
                                 chat_log, enable_web_search=web_search
@@ -197,7 +203,6 @@ class CodexAssistConversationEntity(
                             reasoning_summary=reasoning_summary,
                             text_verbosity=text_verbosity,
                             citation_sink=citations,
-                            citation_footer_sink=citation_footers,
                         )
                     except CodexAuthenticationError as retry_err:
                         LOGGER.warning(
@@ -245,7 +250,7 @@ class CodexAssistConversationEntity(
             )
 
         result = conversation.async_get_result_from_chat_log(user_input, chat_log)
-        _separate_citations_from_result_speech(result, citations, citation_footers)
+        _attach_citations_card(result, citations)
         return result
 
 
@@ -269,7 +274,6 @@ async def _stream_codex_turn_into_chat_log(
     text_verbosity: str,
     text_format: dict[str, Any] | None = None,
     citation_sink: list[CodexCitation] | None = None,
-    citation_footer_sink: list[str] | None = None,
 ) -> bool:
     tool_call_requested = False
 
@@ -292,7 +296,6 @@ async def _stream_codex_turn_into_chat_log(
             ),
             on_tool_call=mark_tool_call_requested,
             citation_sink=citation_sink,
-            citation_footer_sink=citation_footer_sink,
         ),
     ):
         pass
@@ -304,17 +307,14 @@ async def _codex_stream_to_assistant_deltas(
     *,
     on_tool_call: Callable[[], None] | None = None,
     citation_sink: list[CodexCitation] | None = None,
-    citation_footer_sink: list[str] | None = None,
 ) -> AsyncIterator[AssistantContentDeltaDict]:
     started = False
-    citations: list[CodexCitation] = []
     seen_urls: set[str] = set()
     async for delta in stream:
         if isinstance(delta, CodexCitationDelta):
             citation = _safe_citation(delta.citation)
             if citation is not None and citation.url not in seen_urls:
                 seen_urls.add(citation.url)
-                citations.append(citation)
                 if citation_sink is not None and all(
                     existing.url != citation.url for existing in citation_sink
                 ):
@@ -337,13 +337,6 @@ async def _codex_stream_to_assistant_deltas(
                     )
                 ]
             }
-    if citations:
-        if not started:
-            yield {"role": "assistant"}
-        footer = _citation_footer(citations)
-        if citation_footer_sink is not None:
-            citation_footer_sink.append(footer)
-        yield {"content": footer}
 
 
 def _safe_citation(citation: CodexCitation) -> CodexCitation | None:
@@ -381,27 +374,13 @@ def _citation_lines(citations: list[CodexCitation]) -> str:
     return "\n".join(f"- {citation.title} — <{citation.url}>" for citation in citations)
 
 
-def _citation_footer(citations: list[CodexCitation]) -> str:
-    return f"{_SOURCES_SEPARATOR}{_citation_lines(citations)}"
-
-
-def _separate_citations_from_result_speech(
+def _attach_citations_card(
     result: conversation.ConversationResult,
     citations: list[CodexCitation],
-    citation_footers: list[str],
 ) -> None:
     if not citations:
         return
-    response = result.response
-    speech = getattr(response, "speech", None)
-    if isinstance(speech, dict):
-        plain = speech.get("plain")
-        if isinstance(plain, dict) and isinstance(plain.get("speech"), str):
-            for footer in reversed(citation_footers):
-                if plain["speech"].endswith(footer):
-                    plain["speech"] = plain["speech"].removesuffix(footer).rstrip()
-                    break
-    response.async_set_card("Sources", _citation_lines(citations))
+    result.response.async_set_card("Sources", _citation_lines(citations))
 
 
 async def _refresh_runtime_tokens(
@@ -449,6 +428,18 @@ def _instructions_from_chat_log(
         ):
             return content.content
     return fallback_prompt
+
+
+def _instructions_for_turn(
+    chat_log: conversation.ChatLog,
+    fallback_prompt: str,
+    *,
+    web_search: bool,
+) -> str:
+    instructions = _instructions_from_chat_log(chat_log, fallback_prompt)
+    if not web_search:
+        return instructions
+    return f"{instructions.rstrip()}\n\n{_WEB_SEARCH_CITATION_INSTRUCTIONS}"
 
 
 async def _codex_input_from_chat_log(

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.0-beta.1"
+  "version": "0.4.0-beta.2"
 }

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.3.2"
+  "version": "0.4.0-beta.1"
 }

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.0-beta.3"
+  "version": "0.4.0"
 }

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.0-beta.2"
+  "version": "0.4.0-beta.3"
 }

--- a/custom_components/codex_assist/strings.json
+++ b/custom_components/codex_assist/strings.json
@@ -11,7 +11,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       },
       "device": {
@@ -32,7 +33,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       }
     },
@@ -59,7 +61,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       }
     }

--- a/custom_components/codex_assist/translations/en.json
+++ b/custom_components/codex_assist/translations/en.json
@@ -11,7 +11,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       },
       "device": {
@@ -32,7 +33,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       }
     },
@@ -59,7 +61,8 @@
           "prompt": "System prompt",
           "reasoning_effort": "Reasoning effort",
           "reasoning_summary": "Reasoning summary",
-          "text_verbosity": "Text verbosity"
+          "text_verbosity": "Text verbosity",
+          "web_search": "Enable hosted web search"
         }
       }
     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,8 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 - **Model discovery**: offers a curated fallback model list and, when authenticated, asks the Codex backend for the currently available model IDs.
 - **Conversation agent**: registers `conversation.codex_assist` so Codex Assist can be selected in Home Assistant Assist pipelines.
 - **AI Task entity**: registers a native AI Task provider for structured data generation, attachment-aware prompts, and image generation.
-- **Codex client**: refreshes tokens when possible and sends conversation turns to the Codex-compatible service interface.
+- **Runtime token coordinator**: serializes refresh-token rotation per config entry so concurrent Conversation and AI Task requests reuse the winning refresh instead of invalidating one another.
+- **Codex client**: sends conversation turns to the Codex-compatible service interface and normalizes its response stream.
 - **Assist tool bridge**: maps model-requested actions into Home Assistant's Assist LLM API rather than calling services directly.
 
 ## Request flow
@@ -25,7 +26,7 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 ## AI Task flow
 
 1. Home Assistant sends an AI Task request to the Codex Assist AI Task entity.
-2. For data-generation tasks, Codex Assist translates instructions and supported attachments into Codex-compatible input items.
+2. For data-generation tasks, Codex Assist translates instructions and supported attachments into Codex-compatible input items. When Home Assistant supplies a structure, Codex Assist sends it as a native JSON-schema response format and validates the returned data against the same structure.
 3. For image-generation tasks, Codex Assist requests an image from the Codex-compatible service interface using curated quality and size options.
 4. Codex Assist returns the structured data or generated image bytes through Home Assistant's native AI Task result types.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,6 +12,7 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 - **AI Task entity**: registers a native AI Task provider for structured data generation, attachment-aware prompts, and image generation.
 - **Runtime token coordinator**: serializes refresh-token rotation per config entry so concurrent Conversation and AI Task requests reuse the winning refresh instead of invalidating one another.
 - **Codex client**: sends conversation turns to the Codex-compatible service interface and normalizes its response stream.
+- **Hosted web search**: when explicitly enabled, adds the backend `web_search` tool and converts structured URL annotations into a validated source footer/card. Unsupported or unsafe citation URLs are discarded.
 - **Assist tool bridge**: maps model-requested actions into Home Assistant's Assist LLM API rather than calling services directly.
 
 ## Request flow
@@ -21,12 +22,13 @@ Codex Assist is a Home Assistant custom integration that registers a native Assi
 3. Codex Assist sends the conversation to the Codex-compatible service interface.
 4. If Codex requests a Home Assistant tool call, Codex Assist maps that request into Home Assistant's Assist LLM API.
 5. Home Assistant validates and executes the allowed Assist tool call using its normal exposed-entity controls.
-6. Codex Assist returns the final response to Home Assistant.
+6. When hosted search is enabled, Codex Assist preserves validated citations for displayed output and removes only its generated source footer from speech.
+7. Codex Assist returns the final response to Home Assistant.
 
 ## AI Task flow
 
 1. Home Assistant sends an AI Task request to the Codex Assist AI Task entity.
-2. For data-generation tasks, Codex Assist translates instructions and supported attachments into Codex-compatible input items. When Home Assistant supplies a structure, Codex Assist sends it as a native JSON-schema response format and validates the returned data against the same structure.
+2. For data-generation tasks, Codex Assist translates instructions and supported attachments into Codex-compatible input items. When Home Assistant supplies a structure, Codex Assist sends it as a native JSON-schema response format, validates the returned data against the same structure, and disables web search so citation text cannot invalidate the JSON result.
 3. For image-generation tasks, Codex Assist requests an image from the Codex-compatible service interface using curated quality and size options.
 4. Codex Assist returns the structured data or generated image bytes through Home Assistant's native AI Task result types.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -3,6 +3,7 @@
 ## Automated checks
 
 ```bash
+uv sync --all-extras --dev
 uv run ruff check .
 uv run pytest -q
 ```
@@ -12,9 +13,14 @@ The fast suite under `tests/` uses lightweight Home Assistant fakes. Run the `te
 ```bash
 uv run --isolated --python 3.14 --with-requirements requirements_test_ha.txt \
   python -m pytest tests_ha -q
+
+uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt \
+  python -m pytest tests_ha -q
 ```
 
-CI runs both lanes on pushes and pull requests, and runs the Home Assistant harness weekly.
+CI runs the fast suite plus real-Home-Assistant contract lanes against both the
+latest release and Home Assistant 2026.5.0, the minimum supported version. The
+latest-version lane also runs weekly to catch upstream breakage.
 
 ## Release-candidate install
 
@@ -57,5 +63,9 @@ Home Assistant's normal Assist popup may not expose file uploads. Use AI Task su
 3. Call `ai_task.generate_image` with a plain prompt and one non-default size.
 4. Confirm text-only Assist still works afterward.
 5. Confirm logs do not contain tokens, local file contents, or base64 payloads.
+
+Codex Assist accepts up to four image attachments, with a 10 MiB per-image limit and
+a 20 MiB aggregate limit per request. Requests over the count or aggregate limit fail
+instead of silently discarding attachments.
 
 Before publishing screenshots, remove private URLs, account details, tokens, device codes, and private entity or dashboard names.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,9 +18,11 @@ uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt
   python -m pytest tests_ha -q
 ```
 
-CI runs the fast suite plus real-Home-Assistant contract lanes against both the
-latest release and Home Assistant 2026.5.0, the minimum supported version. The
-latest-version lane also runs weekly to catch upstream breakage.
+CI runs the fast suite plus pinned real-Home-Assistant contract lanes against
+Home Assistant 2026.8.3 and Home Assistant 2026.5.0, the minimum supported
+version. Update the stable pins in `requirements_test_ha.txt` together when
+advancing that contract. Both lanes also run weekly to catch regressions without
+silently resolving a prerelease or a newly incompatible test harness mid-run.
 
 ## Release-candidate install
 

--- a/docs/spikes/web-search-contract.md
+++ b/docs/spikes/web-search-contract.md
@@ -1,6 +1,6 @@
 # Codex hosted web-search contract spike
 
-Status: **request/protocol evidence captured; live Codex-backend acceptance still requires a Codex Assist-owned OAuth grant.**
+Status: **fixture-backed implementation exists on the feature branch; live Codex-backend acceptance still requires a Codex Assist-owned OAuth grant.**
 
 Foundation checkpoint: `d8e2197` (`Harden Codex runtime contracts`)
 
@@ -74,7 +74,7 @@ Do not source that token from Codex CLI, an editor, or another assistant. The pr
 
 ## Decision
 
-**Proceed with web search, but do not port the fork directly.** The likely implementation is small at the request seam, default-off, and can coexist with HA tools. Before user-facing implementation, obtain one dedicated Codex Assist OAuth authorization and run the sanitized probe to establish:
+**Proceed with web search, but do not port the fork directly.** The implementation is small at the request seam, default-off, and coexists with HA tools in fixture and real-Home-Assistant contract tests. Before release or claiming backend compatibility, obtain one dedicated Codex Assist OAuth authorization and run the sanitized probe to establish:
 
 1. whether the ChatGPT Codex backend accepts `web_search` for supported models/plans;
 2. exact progress/output/annotation events it emits;

--- a/docs/spikes/web-search-contract.md
+++ b/docs/spikes/web-search-contract.md
@@ -1,0 +1,80 @@
+# Codex hosted web-search contract spike
+
+Status: **request/protocol evidence captured; live Codex-backend acceptance still requires a Codex Assist-owned OAuth grant.**
+
+Foundation checkpoint: `d8e2197` (`Harden Codex runtime contracts`)
+
+## Question
+
+Can Codex Assist add hosted web search through its existing Responses request seam without weakening the Home Assistant tool boundary or losing citations?
+
+## Evidence
+
+### First-party OpenAI Responses contract
+
+At OpenAI Python commit [`9917c6e`](https://github.com/openai/openai-python/tree/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses):
+
+- [`web_search_tool_param.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/web_search_tool_param.py) defines hosted tools with `type: "web_search"` (or the dated variant). It supports optional domain filters, `low|medium|high` search context, approximate location, and an external-web-access switch.
+- Search execution emits distinct progress events:
+  - [`response.web_search_call.in_progress`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_web_search_call_in_progress_event.py)
+  - [`response.web_search_call.searching`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_web_search_call_searching_event.py)
+  - [`response.web_search_call.completed`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_web_search_call_completed_event.py)
+- [`response_function_web_search.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_function_web_search.py) defines `web_search_call` output items with search, open-page, or find-in-page actions and a status.
+- Citations are structured output annotations, not merely prose conventions. [`response_output_text_annotation_added_event.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_output_text_annotation_added_event.py) defines `response.output_text.annotation.added`; `url_citation` includes title, URL, and text-span indexes. [`response_output_text.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_output_text.py) also carries annotations on completed output text.
+
+These files are generated from the first-party [OpenAI OpenAPI repository](https://github.com/openai/openai-openapi/tree/172101000e7be21103c405aa8bedf918039f886f).
+
+### Public fork evidence
+
+Fork commit [`d73bed5`](https://github.com/greimela/ha-codex-assist/commit/d73bed5b5426) adds a default-off option and appends exactly `{"type": "web_search"}` to the same tools list as HA function tools. That is a plausible request shape and matches the first-party contract.
+
+The follow-up commits [`9876bb8`](https://github.com/greimela/ha-codex-assist/commit/9876bb807ee7) and [`a0b12a7`](https://github.com/greimela/ha-codex-assist/commit/a0b12a7e902b) strip Markdown links/source sections with regular expressions for TTS. They do **not** parse or preserve `url_citation` annotations, record raw web-search events, prove model/plan support, or show hosted CI/live probe evidence. Therefore the fork demonstrates a small product wiring idea, not a verified backend contract.
+
+## Repository fit
+
+The existing `CodexClient` already passes tool dictionaries through the Responses payload, so no provider abstraction or plugin registry is needed. However, its public stream delta model currently represents only text and HA function calls. Unknown search progress and annotation events are ignored.
+
+That means simply copying the fork could produce text, but it would throw away the structured citation contract and then guess at citations with regex. We should not ship that behavior.
+
+## Privacy-safe probe artifact
+
+`scripts/probe_web_search_contract.py` sends one fixed request:
+
+- no HA state, entity IDs, conversation history, attachments, tool results, location, or user text;
+- `store: false`;
+- `search_context_size: low`;
+- results restricted to `iana.org`;
+- sanitized output containing event names/key shapes and annotation types only—never response text, queries, URLs, IDs, or credentials.
+
+Dry run:
+
+```bash
+uv run python scripts/probe_web_search_contract.py --dry-run
+```
+
+Live run requires an access token issued to **Codex Assist itself**:
+
+```bash
+CODEX_ASSIST_ACCESS_TOKEN='[ephemeral integration-owned token]' \
+  uv run python scripts/probe_web_search_contract.py
+```
+
+Do not source that token from Codex CLI, an editor, or another assistant. The probe intentionally refuses to run without an explicitly supplied integration-owned token.
+
+## Executed result
+
+- Dry run succeeded and produced the fixed request payload.
+- Privacy/sanitization tests passed.
+- No integration-owned token exists in this checkout/session, so the live network request was **not** run.
+- No Codex CLI/editor credentials were inspected or copied.
+
+## Decision
+
+**Proceed with web search, but do not port the fork directly.** The likely implementation is small at the request seam, default-off, and can coexist with HA tools. Before user-facing implementation, obtain one dedicated Codex Assist OAuth authorization and run the sanitized probe to establish:
+
+1. whether the ChatGPT Codex backend accepts `web_search` for supported models/plans;
+2. exact progress/output/annotation events it emits;
+3. unsupported-model and usage-limit error shapes;
+4. whether URL citations can be converted into visible HA chat links while the TTS path receives citation-free speech.
+
+If live evidence matches the first-party contract, add an explicit citation delta/result type in `CodexClient`, preserve citations for displayed Assist/AI Task output, and clean only the TTS rendering. Keep search opt-in and never automatically turn HA state, attachments, or tool output into search queries.

--- a/docs/spikes/web-search-contract.md
+++ b/docs/spikes/web-search-contract.md
@@ -15,6 +15,7 @@ Can Codex Assist add hosted web search through its existing Responses request se
 At OpenAI Python commit [`9917c6e`](https://github.com/openai/openai-python/tree/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses):
 
 - [`web_search_tool_param.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/web_search_tool_param.py) defines hosted tools with `type: "web_search"` (or the dated variant). It supports optional domain filters, `low|medium|high` search context, approximate location, and an external-web-access switch.
+- The [OpenAI web-search guide](https://platform.openai.com/docs/guides/tools-web-search) documents `include: ["web_search_call.action.sources"]` when callers need the complete consulted-source list. It also documents model-specific limitations, including that GPT-5 web search is incompatible with minimal reasoning.
 - Search execution emits distinct progress events:
   - [`response.web_search_call.in_progress`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_web_search_call_in_progress_event.py)
   - [`response.web_search_call.searching`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_web_search_call_searching_event.py)
@@ -23,6 +24,8 @@ At OpenAI Python commit [`9917c6e`](https://github.com/openai/openai-python/tree
 - Citations are structured output annotations, not merely prose conventions. [`response_output_text_annotation_added_event.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_output_text_annotation_added_event.py) defines `response.output_text.annotation.added`; `url_citation` includes title, URL, and text-span indexes. [`response_output_text.py`](https://github.com/openai/openai-python/blob/9917c6e28e66e90e1227b3d223c06a8c5441515a/src/openai/types/responses/response_output_text.py) also carries annotations on completed output text.
 
 These files are generated from the first-party [OpenAI OpenAPI repository](https://github.com/openai/openai-openapi/tree/172101000e7be21103c405aa8bedf918039f886f).
+
+This is strong evidence for the public Responses contract, but it does **not** prove that the private ChatGPT endpoint used here—`https://chatgpt.com/backend-api/codex/responses`—accepts every field or emits every documented event. That gap is exactly what the live probe must close.
 
 ### Public fork evidence
 
@@ -43,6 +46,7 @@ That means simply copying the fork could produce text, but it would throw away t
 - no HA state, entity IDs, conversation history, attachments, tool results, location, or user text;
 - `store: false`;
 - `search_context_size: low`;
+- explicit external-web access and `include: ["web_search_call.action.sources"]`;
 - results restricted to `iana.org`;
 - sanitized output containing event names/key shapes and annotation types only—never response text, queries, URLs, IDs, or credentials.
 
@@ -78,3 +82,5 @@ Do not source that token from Codex CLI, an editor, or another assistant. The pr
 4. whether URL citations can be converted into visible HA chat links while the TTS path receives citation-free speech.
 
 If live evidence matches the first-party contract, add an explicit citation delta/result type in `CodexClient`, preserve citations for displayed Assist/AI Task output, and clean only the TTS rendering. Keep search opt-in and never automatically turn HA state, attachments, or tool output into search queries.
+
+Do not hard-code a presumed HTTP status, error code, or retry rule for unsupported models. Classify capability, authentication, quota, and transient failures only from an observed HTTP/SSE payload, and retain the integration's existing bounded retry policy for genuinely transient failures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.0-beta.3"
+version = "0.4.0"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.3.2"
+version = "0.4.0-beta.1"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Codex Assist contributors" }]
 dependencies = [
   "httpx>=0.27",
+  "voluptuous-openapi>=0.3,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.3"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/requirements_test_ha.txt
+++ b/requirements_test_ha.txt
@@ -1,11 +1,14 @@
-# Real Home Assistant smoke-test environment (Python 3.14+).
-# Intentionally unpinned so scheduled CI runs track the latest Home Assistant
-# release and surface upstream breakage early.
-pytest-homeassistant-custom-component
+# Current stable Home Assistant contract (Python 3.14+).
+# Update these pins together when advancing the supported stable contract.
+homeassistant==2026.8.3
+pytest-homeassistant-custom-component==0.13.357
 
-# Runtime requirements of the Home Assistant conversation and ai_task
-# components, which the smoke tests exercise but the test harness does not
-# bundle. ai_task transitively imports camera, which needs PyTurboJPEG.
-hassil
-home-assistant-intents
-PyTurboJPEG
+# Runtime requirements declared by the Home Assistant conversation and camera
+# components exercised by these tests.
+gazetteer-matcher==1.0.0
+hassil==3.12.0
+home-assistant-intents==2026.8.25
+PyTurboJPEG==1.8.3
+
+# Imported directly by Codex Assist for AI Task schema conversion.
+voluptuous-openapi==0.4.1

--- a/requirements_test_ha_min.txt
+++ b/requirements_test_ha_min.txt
@@ -1,0 +1,9 @@
+# Minimum supported Home Assistant contract (Python 3.14+).
+homeassistant==2026.5.0
+pytest-homeassistant-custom-component==0.13.329
+
+# Runtime requirements declared by Home Assistant 2026.5.0 for the
+# conversation and camera components exercised by these tests.
+hassil==3.5.0
+home-assistant-intents==2026.5.5
+PyTurboJPEG==1.8.3

--- a/requirements_test_ha_min.txt
+++ b/requirements_test_ha_min.txt
@@ -7,3 +7,4 @@ pytest-homeassistant-custom-component==0.13.329
 hassil==3.5.0
 home-assistant-intents==2026.5.5
 PyTurboJPEG==1.8.3
+voluptuous-openapi==0.3.0

--- a/scripts/probe_web_search_contract.py
+++ b/scripts/probe_web_search_contract.py
@@ -43,10 +43,12 @@ def probe_payload(model: str) -> dict[str, Any]:
         "tools": [
             {
                 "type": "web_search",
+                "external_web_access": True,
                 "filters": {"allowed_domains": ["iana.org"]},
                 "search_context_size": "low",
             }
         ],
+        "include": ["web_search_call.action.sources"],
         "stream": True,
         "store": False,
     }

--- a/scripts/probe_web_search_contract.py
+++ b/scripts/probe_web_search_contract.py
@@ -1,0 +1,157 @@
+"""Privacy-safe throwaway probe for the Codex hosted web-search contract.
+
+This script records event structure, not response text, search queries, URLs, or
+credentials. Use only a token issued to Codex Assist itself; never borrow Codex
+CLI/editor credentials.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from custom_components.codex_assist.codex_client import (  # noqa: E402
+    CODEX_BACKEND_BASE_URL,
+    codex_headers,
+)
+
+DEFAULT_MODEL = "gpt-5.4"
+FIXED_PROMPT = (
+    "Use web search to identify the organization that maintains the IANA "
+    "Reserved Domains page. Cite the source in the response."
+)
+
+
+def probe_payload(model: str) -> dict[str, Any]:
+    """Return the fixed, data-minimized probe payload."""
+    return {
+        "model": model,
+        "instructions": (
+            "Answer only from the hosted web-search tool. Do not use or request "
+            "Home Assistant state, user data, attachments, or prior conversation context."
+        ),
+        "input": [{"role": "user", "content": FIXED_PROMPT}],
+        "tools": [
+            {
+                "type": "web_search",
+                "filters": {"allowed_domains": ["iana.org"]},
+                "search_context_size": "low",
+            }
+        ],
+        "stream": True,
+        "store": False,
+    }
+
+
+def summarize_event(event: dict[str, Any]) -> dict[str, Any]:
+    """Keep contract shape while dropping text, queries, URLs, and identifiers."""
+    summary: dict[str, Any] = {
+        "type": event.get("type"),
+        "keys": sorted(event),
+    }
+    item = event.get("item")
+    if isinstance(item, dict):
+        summary["item"] = {
+            "type": item.get("type"),
+            "status": item.get("status"),
+            "keys": sorted(item),
+        }
+        action = item.get("action")
+        if isinstance(action, dict):
+            summary["item"]["action"] = {
+                "type": action.get("type"),
+                "keys": sorted(action),
+            }
+    annotation = event.get("annotation")
+    if isinstance(annotation, dict):
+        summary["annotation"] = {
+            "type": annotation.get("type"),
+            "keys": sorted(annotation),
+        }
+    delta = event.get("delta")
+    if isinstance(delta, str):
+        summary["delta_length"] = len(delta)
+    response = event.get("response")
+    if isinstance(response, dict):
+        error = response.get("error")
+        summary["response"] = {
+            "status": response.get("status"),
+            "error_code": error.get("code") if isinstance(error, dict) else None,
+        }
+    return summary
+
+
+async def run_probe(*, model: str, access_token: str) -> int:
+    """Run the one-shot hosted-tool probe and emit sanitized JSON lines."""
+    url = f"{CODEX_BACKEND_BASE_URL}/responses"
+    async with httpx.AsyncClient(timeout=60) as client:
+        async with client.stream(
+            "POST",
+            url,
+            headers=codex_headers(access_token),
+            json=probe_payload(model),
+        ) as response:
+            if response.status_code != 200:
+                print(
+                    json.dumps(
+                        {"http_status": response.status_code, "result": "request_rejected"},
+                        sort_keys=True,
+                    )
+                )
+                return 1
+            event_name: str | None = None
+            data_lines: list[str] = []
+            async for line in response.aiter_lines():
+                if line.startswith("event:"):
+                    event_name = line.removeprefix("event:").strip()
+                elif line.startswith("data:"):
+                    data_lines.append(line.removeprefix("data:").lstrip())
+                elif not line and data_lines:
+                    raw = "\n".join(data_lines)
+                    data_lines.clear()
+                    try:
+                        event = json.loads(raw)
+                    except json.JSONDecodeError:
+                        print(json.dumps({"type": event_name, "result": "invalid_json"}))
+                        event_name = None
+                        continue
+                    if isinstance(event, dict):
+                        if event_name and "type" not in event:
+                            event["type"] = event_name
+                        print(json.dumps(summarize_event(event), sort_keys=True))
+                    event_name = None
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    payload = probe_payload(args.model)
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return 0
+
+    token = os.environ.get("CODEX_ASSIST_ACCESS_TOKEN", "").strip()
+    if not token:
+        print(
+            "No integration-owned CODEX_ASSIST_ACCESS_TOKEN is available; live probe not run.",
+            file=sys.stderr,
+        )
+        return 2
+    return asyncio.run(run_probe(model=args.model, access_token=token))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ha_fakes.py
+++ b/tests/ha_fakes.py
@@ -147,6 +147,9 @@ def install_homeassistant_fakes(monkeypatch):
         def __call__(self, value):
             return value
 
+    class Invalid(Exception):
+        pass
+
     class Optional:
         def __init__(self, key, default=None):
             self.key = key
@@ -203,7 +206,11 @@ def install_homeassistant_fakes(monkeypatch):
     selector.SelectSelectorConfig = SelectSelectorConfig
     selector.SelectSelectorMode = SelectSelectorMode
     util_json.json_loads = __import__("json").loads
-    voluptuous_openapi.convert = lambda schema, custom_serializer=None: schema
+    util.slugify = lambda value: value.lower().replace(" ", "_")
+    voluptuous_openapi.convert = lambda schema, custom_serializer=None: getattr(
+        schema, "schema", schema
+    )
+    vol.Invalid = Invalid
     vol.Schema = Schema
     vol.Optional = Optional
 

--- a/tests/test_ai_task_behavior.py
+++ b/tests/test_ai_task_behavior.py
@@ -100,6 +100,12 @@ def test_structured_output_format_normalizes_api_name(ai_task_module, name, expe
     assert ai_task_module._structured_output_format(task, chat_log)["name"] == expected
 
 
+def test_ai_task_web_search_is_disabled_for_structured_output(ai_task_module):
+    assert ai_task_module._web_search_enabled(True, text_format=None) is True
+    assert ai_task_module._web_search_enabled(True, text_format={"type": "json_schema"}) is False
+    assert ai_task_module._web_search_enabled(False, text_format=None) is False
+
+
 @pytest.mark.asyncio
 async def test_ai_task_generate_data_reports_temporary_auth_without_reauth(
     ai_task_module,
@@ -126,6 +132,7 @@ async def test_ai_task_generate_data_reports_temporary_auth_without_reauth(
     )()
     task = type("Task", (), {"structure": None})()
     chat_log = type("ChatLog", (), {})()
+
     class FailingCoordinator:
         async def resolve(self, *args, **kwargs):
             return await fail_temporarily()

--- a/tests/test_ai_task_behavior.py
+++ b/tests/test_ai_task_behavior.py
@@ -34,9 +34,9 @@ def test_structured_data_from_text_returns_plain_text_without_structure(ai_task_
 
 
 def test_structured_data_from_text_parses_json_when_structure_requested(ai_task_module):
-    assert ai_task_module._structured_data_from_text('{"state":"on"}', {"type": "object"}) == {
-        "state": "on"
-    }
+    structure = ai_task_module.vol.Schema({"state": str})
+
+    assert ai_task_module._structured_data_from_text('{"state":"on"}', structure) == {"state": "on"}
 
 
 def test_structured_data_from_text_rejects_invalid_json_when_structure_requested(
@@ -44,9 +44,60 @@ def test_structured_data_from_text_rejects_invalid_json_when_structure_requested
     caplog,
 ):
     with pytest.raises(RuntimeError, match="invalid JSON"):
-        ai_task_module._structured_data_from_text("not json", {"type": "object"})
+        ai_task_module._structured_data_from_text(
+            "not json", ai_task_module.vol.Schema({"state": str})
+        )
     assert "not json" not in caplog.text
     assert "Failed to parse Codex Assist AI Task JSON response (8 chars)" in caplog.text
+
+
+def test_structured_data_from_text_validates_requested_structure(ai_task_module):
+    class RejectingStructure:
+        def __call__(self, value):
+            raise ai_task_module.vol.Invalid("state is required")
+
+    with pytest.raises(RuntimeError, match="did not match the requested structure"):
+        ai_task_module._structured_data_from_text('{"wrong":"shape"}', RejectingStructure())
+
+
+def test_structured_output_format_converts_ai_task_schema(ai_task_module):
+    task = type(
+        "Task",
+        (),
+        {
+            "name": "Porch State",
+            "structure": ai_task_module.vol.Schema({"state": str}),
+        },
+    )()
+    chat_log = type(
+        "ChatLog",
+        (),
+        {"llm_api": type("LLMApi", (), {"custom_serializer": None})()},
+    )()
+
+    assert ai_task_module._structured_output_format(task, chat_log) == {
+        "type": "json_schema",
+        "name": "porch_state",
+        "schema": {"state": str},
+    }
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("x" * 65, "x" * 64),
+        ("!!!", "structured_output"),
+    ],
+)
+def test_structured_output_format_normalizes_api_name(ai_task_module, name, expected):
+    task = type(
+        "Task",
+        (),
+        {"name": name, "structure": ai_task_module.vol.Schema({"state": str})},
+    )()
+    chat_log = type("ChatLog", (), {"llm_api": None})()
+
+    assert ai_task_module._structured_output_format(task, chat_log)["name"] == expected
 
 
 @pytest.mark.asyncio
@@ -75,7 +126,15 @@ async def test_ai_task_generate_data_reports_temporary_auth_without_reauth(
     )()
     task = type("Task", (), {"structure": None})()
     chat_log = type("ChatLog", (), {})()
-    monkeypatch.setattr(ai_task_module, "resolve_runtime_tokens", fail_temporarily)
+    class FailingCoordinator:
+        async def resolve(self, *args, **kwargs):
+            return await fail_temporarily()
+
+    monkeypatch.setattr(
+        ai_task_module,
+        "runtime_token_coordinator",
+        lambda entry: FailingCoordinator(),
+    )
 
     with pytest.raises(RuntimeError, match="rate limited"):
         await entity._async_generate_data(task, chat_log)
@@ -120,7 +179,11 @@ async def test_ai_task_chat_log_retry_propagates_reauth_required(
                     )(),
                 },
             )(),
-            entry=type("Entry", (), {"data": {}})(),
+            entry=type(
+                "Entry",
+                (),
+                {"data": {"access_token": "access-1", "refresh_token": "refresh-1"}},
+            )(),
             auth_client=ReauthAuthClient(),
             tokens=CodexTokenSet("access-1", "refresh-1"),
             codex=object(),
@@ -175,7 +238,11 @@ async def test_ai_task_chat_log_retry_reauths_when_refreshed_token_is_rejected(
                     )(),
                 },
             )(),
-            entry=type("Entry", (), {"data": {}})(),
+            entry=type(
+                "Entry",
+                (),
+                {"data": {"access_token": "access-1", "refresh_token": "refresh-1"}},
+            )(),
             auth_client=RefreshAuthClient(),
             tokens=CodexTokenSet("access-1", "refresh-1"),
             codex=object(),
@@ -226,7 +293,11 @@ async def test_ai_task_image_retry_reauths_when_refreshed_token_is_rejected(
                     )(),
                 },
             )(),
-            entry=type("Entry", (), {"data": {}})(),
+            entry=type(
+                "Entry",
+                (),
+                {"data": {"access_token": "access-1", "refresh_token": "refresh-1"}},
+            )(),
             auth_client=RefreshAuthClient(),
             tokens=CodexTokenSet("access-1", "refresh-1"),
             codex=RejectingImageCodex(),

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from custom_components.codex_assist.codex_client import (
+    CODEX_STREAM_TIMEOUT,
     CodexCitationDelta,
     CodexClient,
     CodexRateLimitError,
@@ -78,6 +79,7 @@ async def test_stream_turn_yields_text_deltas_and_posts_advanced_options():
     assert payload["reasoning"] == {"effort": "medium", "summary": "auto"}
     assert payload["include"] == ["reasoning.encrypted_content"]
     assert payload["text"] == {"verbosity": "low"}
+    assert http.calls[0][2]["timeout"] == CODEX_STREAM_TIMEOUT
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -8,7 +8,6 @@ from custom_components.codex_assist.codex_client import (
     CodexRateLimitError,
     CodexTextDelta,
     CodexToolCallDelta,
-    CodexWebSearchStartedDelta,
 )
 
 
@@ -172,18 +171,6 @@ async def test_stream_turn_yields_structured_web_citations_and_requests_sources(
         200,
         _event(
             {
-                "type": "response.output_item.added",
-                "item": {"type": "web_search_call", "id": "search-1"},
-            }
-        )
-        + _event(
-            {
-                "type": "response.web_search_call.searching",
-                "item_id": "search-1",
-            }
-        )
-        + _event(
-            {
                 "type": "response.output_text.annotation.added",
                 "annotation": citation,
             }
@@ -219,7 +206,6 @@ async def test_stream_turn_yields_structured_web_citations_and_requests_sources(
     ]
 
     citations = [delta.citation for delta in deltas if isinstance(delta, CodexCitationDelta)]
-    assert sum(isinstance(delta, CodexWebSearchStartedDelta) for delta in deltas) == 1
     assert [(citation.title, citation.url) for citation in citations] == [
         ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),
         ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -80,6 +80,39 @@ async def test_stream_turn_yields_text_deltas_and_posts_advanced_options():
 
 
 @pytest.mark.asyncio
+async def test_stream_turn_posts_structured_output_format_with_verbosity():
+    response = FakeStreamResponse(200, [])
+    http = FakeHttpClient(response)
+    client = CodexClient(http_client=http, access_token="token-1")
+    text_format = {
+        "type": "json_schema",
+        "name": "porch_state",
+        "schema": {
+            "type": "object",
+            "properties": {"state": {"type": "string"}},
+            "required": ["state"],
+        },
+    }
+
+    deltas = [
+        delta
+        async for delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Return structured data.",
+            input_items=[{"role": "user", "content": "porch state"}],
+            text_verbosity="low",
+            text_format=text_format,
+        )
+    ]
+
+    assert deltas == []
+    assert http.calls[0][2]["json"]["text"] == {
+        "verbosity": "low",
+        "format": text_format,
+    }
+
+
+@pytest.mark.asyncio
 async def test_stream_turn_yields_function_call_after_arguments_complete():
     response = FakeStreamResponse(
         200,
@@ -180,6 +213,55 @@ async def test_stream_turn_raises_rate_limit_error_for_429():
     client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
 
     with pytest.raises(CodexRateLimitError, match="quota exceeded"):
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="x",
+            input_items=[{"role": "user", "content": "hello"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_raises_rate_limit_error_for_failed_stream_event():
+    response = FakeStreamResponse(
+        200,
+        _event(
+            {
+                "type": "response.failed",
+                "response": {
+                    "error": {
+                        "code": "rate_limit_exceeded",
+                        "message": "synthetic quota failure",
+                    }
+                },
+            }
+        ),
+    )
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+
+    with pytest.raises(CodexRateLimitError, match="synthetic quota failure"):
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="x",
+            input_items=[{"role": "user", "content": "hello"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_raises_for_incomplete_stream_event():
+    response = FakeStreamResponse(
+        200,
+        _event(
+            {
+                "type": "response.incomplete",
+                "response": {"incomplete_details": {"reason": "max_output_tokens"}},
+            }
+        ),
+    )
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+
+    with pytest.raises(RuntimeError, match="incomplete.*max_output_tokens"):
         async for _delta in client.stream_turn(
             model="gpt-5.4",
             instructions="x",

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -8,6 +8,7 @@ from custom_components.codex_assist.codex_client import (
     CodexRateLimitError,
     CodexTextDelta,
     CodexToolCallDelta,
+    CodexWebSearchStartedDelta,
 )
 
 
@@ -171,6 +172,18 @@ async def test_stream_turn_yields_structured_web_citations_and_requests_sources(
         200,
         _event(
             {
+                "type": "response.output_item.added",
+                "item": {"type": "web_search_call", "id": "search-1"},
+            }
+        )
+        + _event(
+            {
+                "type": "response.web_search_call.searching",
+                "item_id": "search-1",
+            }
+        )
+        + _event(
+            {
                 "type": "response.output_text.annotation.added",
                 "annotation": citation,
             }
@@ -206,6 +219,7 @@ async def test_stream_turn_yields_structured_web_citations_and_requests_sources(
     ]
 
     citations = [delta.citation for delta in deltas if isinstance(delta, CodexCitationDelta)]
+    assert sum(isinstance(delta, CodexWebSearchStartedDelta) for delta in deltas) == 1
     assert [(citation.title, citation.url) for citation in citations] == [
         ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),
         ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from custom_components.codex_assist.codex_client import (
+    CodexCitationDelta,
     CodexClient,
     CodexRateLimitError,
     CodexTextDelta,
@@ -155,6 +156,64 @@ async def test_stream_turn_yields_function_call_after_arguments_complete():
     assert tool_delta.tool_call.id == "call-1"
     assert tool_delta.tool_call.name == "HassTurnOn"
     assert tool_delta.tool_call.arguments == {"name": "Kitchen", "domain": "light"}
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_yields_structured_web_citations_and_requests_sources():
+    citation = {
+        "type": "url_citation",
+        "title": "IANA Reserved Domains",
+        "url": "https://www.iana.org/help/example-domains",
+        "start_index": 10,
+        "end_index": 22,
+    }
+    response = FakeStreamResponse(
+        200,
+        _event(
+            {
+                "type": "response.output_text.annotation.added",
+                "annotation": citation,
+            }
+        )
+        + _event(
+            {
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Example Domains are maintained by IANA.",
+                            "annotations": [citation],
+                        }
+                    ],
+                },
+            }
+        ),
+    )
+    http = FakeHttpClient(response)
+    client = CodexClient(http_client=http, access_token="token-1")
+
+    deltas = [
+        delta
+        async for delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Use search.",
+            input_items=[{"role": "user", "content": "Who maintains Example Domains?"}],
+            tools=[{"type": "web_search"}],
+            reasoning_effort="low",
+        )
+    ]
+
+    citations = [delta.citation for delta in deltas if isinstance(delta, CodexCitationDelta)]
+    assert [(citation.title, citation.url) for citation in citations] == [
+        ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),
+        ("IANA Reserved Domains", "https://www.iana.org/help/example-domains"),
+    ]
+    assert http.calls[0][2]["json"]["include"] == [
+        "reasoning.encrypted_content",
+        "web_search_call.action.sources",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_client_streaming.py
+++ b/tests/test_codex_client_streaming.py
@@ -167,3 +167,30 @@ async def test_generate_text_surfaces_codex_error_body_for_debugging():
             instructions="x",
             messages=[CodexMessage(role="user", content="hello")],
         )
+
+
+@pytest.mark.asyncio
+async def test_generate_text_raises_for_failed_stream_event():
+    response = FakeResponse(
+        200,
+        text=_sse_event(
+            "response.failed",
+            {
+                "type": "response.failed",
+                "response": {
+                    "error": {
+                        "code": "server_error",
+                        "message": "synthetic backend failure",
+                    }
+                },
+            },
+        ),
+    )
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+
+    with pytest.raises(RuntimeError, match="synthetic backend failure"):
+        await client.generate_text(
+            model="gpt-5.4",
+            instructions="x",
+            messages=[CodexMessage(role="user", content="hello")],
+        )

--- a/tests/test_codex_runtime.py
+++ b/tests/test_codex_runtime.py
@@ -1,10 +1,14 @@
+import asyncio
 import base64
 import json
 
 import pytest
 
 from custom_components.codex_assist.codex_auth import CodexAuthTemporaryError, CodexTokenSet
-from custom_components.codex_assist.codex_runtime import resolve_runtime_tokens
+from custom_components.codex_assist.codex_runtime import (
+    RuntimeTokenCoordinator,
+    resolve_runtime_tokens,
+)
 
 
 def _jwt_with_exp(exp):
@@ -113,3 +117,185 @@ async def test_resolve_runtime_tokens_raises_temporary_error_when_access_token_i
             async_update_entry_data=lambda updated: None,
             now=1_000,
         )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_serializes_proactive_refresh_and_reuses_winner() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    entry_data = {
+        "access_token": _jwt_with_exp(999),
+        "refresh_token": "refresh-1",
+    }
+    calls = []
+
+    class BlockingAuthClient:
+        async def refresh(self, tokens):
+            calls.append(tokens)
+            started.set()
+            await release.wait()
+            return CodexTokenSet(_jwt_with_exp(2_000), "refresh-2")
+
+    def update(updated):
+        entry_data.clear()
+        entry_data.update(updated)
+
+    coordinator = RuntimeTokenCoordinator()
+    first = asyncio.create_task(
+        coordinator.resolve(
+            lambda: entry_data,
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=update,
+            now=1_000,
+        )
+    )
+    await started.wait()
+    second = asyncio.create_task(
+        coordinator.resolve(
+            lambda: entry_data,
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=update,
+            now=1_000,
+        )
+    )
+    await asyncio.sleep(0)
+    release.set()
+
+    first_tokens, second_tokens = await asyncio.gather(first, second)
+
+    assert first_tokens == second_tokens == CodexTokenSet(_jwt_with_exp(2_000), "refresh-2")
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_coordinator_serializes_rejected_token_refresh_and_reuses_winner() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    rejected = CodexTokenSet("access-1", "refresh-1")
+    entry_data = {
+        "access_token": rejected.access_token,
+        "refresh_token": rejected.refresh_token,
+    }
+    calls = []
+
+    class BlockingAuthClient:
+        async def refresh(self, tokens):
+            calls.append(tokens)
+            started.set()
+            await release.wait()
+            return CodexTokenSet("access-2", "refresh-2")
+
+    def update(updated):
+        entry_data.clear()
+        entry_data.update(updated)
+
+    coordinator = RuntimeTokenCoordinator()
+    first = asyncio.create_task(
+        coordinator.refresh_after_rejection(
+            lambda: entry_data,
+            rejected_tokens=rejected,
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=update,
+        )
+    )
+    await started.wait()
+    second = asyncio.create_task(
+        coordinator.refresh_after_rejection(
+            lambda: entry_data,
+            rejected_tokens=rejected,
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=update,
+        )
+    )
+    await asyncio.sleep(0)
+    release.set()
+
+    first_tokens, second_tokens = await asyncio.gather(first, second)
+
+    assert first_tokens == second_tokens == CodexTokenSet("access-2", "refresh-2")
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_proactive_refresh_does_not_overwrite_concurrent_reauth() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    holder = {
+        "data": {
+            "model": "old-model",
+            "access_token": _jwt_with_exp(999),
+            "refresh_token": "refresh-1",
+        }
+    }
+    updates = []
+
+    class BlockingAuthClient:
+        async def refresh(self, tokens):
+            started.set()
+            await release.wait()
+            return CodexTokenSet(_jwt_with_exp(2_000), "rotated-refresh")
+
+    coordinator = RuntimeTokenCoordinator()
+    resolving = asyncio.create_task(
+        coordinator.resolve(
+            lambda: holder["data"],
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=updates.append,
+            now=1_000,
+        )
+    )
+    await started.wait()
+    holder["data"] = {
+        "model": "new-model",
+        "access_token": "reauth-access",
+        "refresh_token": "reauth-refresh",
+    }
+    release.set()
+
+    tokens = await resolving
+
+    assert tokens == CodexTokenSet("reauth-access", "reauth-refresh")
+    assert updates == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_token_refresh_does_not_overwrite_concurrent_reauth() -> None:
+    started = asyncio.Event()
+    release = asyncio.Event()
+    rejected = CodexTokenSet("access-1", "refresh-1")
+    holder = {
+        "data": {
+            "model": "old-model",
+            "access_token": rejected.access_token,
+            "refresh_token": rejected.refresh_token,
+        }
+    }
+    updates = []
+
+    class BlockingAuthClient:
+        async def refresh(self, tokens):
+            started.set()
+            await release.wait()
+            return CodexTokenSet("rotated-access", "rotated-refresh")
+
+    coordinator = RuntimeTokenCoordinator()
+    refreshing = asyncio.create_task(
+        coordinator.refresh_after_rejection(
+            lambda: holder["data"],
+            rejected_tokens=rejected,
+            auth_client=BlockingAuthClient(),
+            async_update_entry_data=updates.append,
+        )
+    )
+    await started.wait()
+    holder["data"] = {
+        "model": "new-model",
+        "access_token": "reauth-access",
+        "refresh_token": "reauth-refresh",
+    }
+    release.set()
+
+    tokens = await refreshing
+
+    assert tokens == CodexTokenSet("reauth-access", "reauth-refresh")
+    assert updates == []

--- a/tests/test_config_flow_behavior.py
+++ b/tests/test_config_flow_behavior.py
@@ -146,6 +146,16 @@ def _schema_defaults(data_schema) -> dict[str, object]:
     }
 
 
+def test_web_search_option_is_default_off_and_preserves_opt_in(config_flow_module):
+    default_schema = config_flow_module._settings_schema({}, model_options=["gpt-5.4"])
+    enabled_schema = config_flow_module._settings_schema(
+        {"web_search": True}, model_options=["gpt-5.4"]
+    )
+
+    assert _schema_defaults(default_schema)["web_search"] is False
+    assert _schema_defaults(enabled_schema)["web_search"] is True
+
+
 def _reconfigure_entry(**overrides):
     data = {
         "model": "gpt-5.4",
@@ -153,6 +163,7 @@ def _reconfigure_entry(**overrides):
         "reasoning_effort": "high",
         "reasoning_summary": "detailed",
         "text_verbosity": "low",
+        "web_search": True,
         "image_model": "gpt-image-2-high",
         "image_size": "1536x1024",
         "access_token": "old-access",
@@ -180,6 +191,7 @@ async def test_reconfigure_shows_form_prefilled_from_entry(config_flow_module):
         "reasoning_effort": "high",
         "reasoning_summary": "detailed",
         "text_verbosity": "low",
+        "web_search": True,
         "image_model": "gpt-image-2-high",
         "image_size": "1536x1024",
     }
@@ -198,6 +210,7 @@ async def test_reconfigure_updates_existing_entry_after_device_token_exchange(
         "reasoning_effort": "medium",
         "reasoning_summary": "auto",
         "text_verbosity": "medium",
+        "web_search": True,
         "image_model": "gpt-image-2-medium",
         "image_size": "1024x1024",
     }
@@ -216,6 +229,7 @@ async def test_reconfigure_updates_existing_entry_after_device_token_exchange(
         "reasoning_effort": "medium",
         "reasoning_summary": "auto",
         "text_verbosity": "medium",
+        "web_search": True,
         "image_model": "gpt-image-2-medium",
         "image_size": "1024x1024",
         "access_token": "access-1",
@@ -243,6 +257,7 @@ async def test_reconfigure_device_code_request_failure_shows_error(config_flow_m
             "reasoning_effort": "medium",
             "reasoning_summary": "auto",
             "text_verbosity": "medium",
+            "web_search": True,
             "image_model": "gpt-image-2-medium",
             "image_size": "1024x1024",
         }
@@ -257,6 +272,7 @@ async def test_reconfigure_device_code_request_failure_shows_error(config_flow_m
         "reasoning_effort": "high",
         "reasoning_summary": "detailed",
         "text_verbosity": "low",
+        "web_search": True,
         "image_model": "gpt-image-2-high",
         "image_size": "1536x1024",
     }

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from custom_components.codex_assist.codex_client import (
+    CodexCitation,
+    CodexCitationDelta,
     CodexTextDelta,
     CodexToolCall,
     CodexToolCallDelta,
@@ -181,6 +183,162 @@ def test_codex_tools_from_chat_log_converts_ha_llm_api_tools(conversation_module
             "strict": False,
         }
     ]
+    assert conversation_module._codex_tools_from_chat_log(
+        FakeChatLog(llm_api=llm_api), enable_web_search=True
+    ) == [*result, {"type": "web_search"}]
+
+
+def test_codex_tools_adds_opt_in_web_search_without_ha_tools(conversation_module):
+    assert (
+        conversation_module._codex_tools_from_chat_log(FakeChatLog(), enable_web_search=False) == []
+    )
+    assert conversation_module._codex_tools_from_chat_log(
+        FakeChatLog(), enable_web_search=True
+    ) == [{"type": "web_search"}]
+
+
+@pytest.mark.asyncio
+async def test_codex_stream_appends_deduplicated_safe_citation_footer(conversation_module):
+    async def stream():
+        yield CodexTextDelta("IANA maintains the reserved domains.")
+        citation = CodexCitation(
+            title="IANA [Reserved] Domains",
+            url="https://www.iana.org/help/example-domains",
+            start_index=0,
+            end_index=4,
+        )
+        yield CodexCitationDelta(citation)
+        yield CodexCitationDelta(citation)
+        yield CodexCitationDelta(
+            CodexCitation(
+                title="Unsafe",
+                url="javascript:alert(1)",
+                start_index=0,
+                end_index=4,
+            )
+        )
+
+    captured = []
+    deltas = [
+        delta
+        async for delta in conversation_module._codex_stream_to_assistant_deltas(
+            stream(),
+            citation_sink=captured,
+        )
+    ]
+
+    assert deltas == [
+        {"role": "assistant"},
+        {"content": "IANA maintains the reserved domains."},
+        {
+            "content": (
+                "\n\nSources:\n"
+                "- IANA \\[Reserved\\] Domains — "
+                "<https://www.iana.org/help/example-domains>"
+            )
+        },
+    ]
+    assert captured == [
+        CodexCitation(
+            title="IANA \\[Reserved\\] Domains",
+            url="https://www.iana.org/help/example-domains",
+            start_index=0,
+            end_index=4,
+        )
+    ]
+
+
+def test_citation_result_keeps_sources_in_card_but_not_speech(conversation_module):
+    class Response:
+        def __init__(self):
+            self.speech = {
+                "plain": {
+                    "speech": (
+                        "IANA maintains the reserved domains. Sources: IANA.\n\nSources:\n"
+                        "- IANA — <https://www.iana.org/help/example-domains>"
+                    )
+                }
+            }
+            self.card = {}
+
+        def async_set_card(self, title, content):
+            self.card["simple"] = {"title": title, "content": content}
+
+    result = type("Result", (), {"response": Response()})()
+    citations = [
+        CodexCitation(
+            title="IANA",
+            url="https://www.iana.org/help/example-domains",
+            start_index=0,
+            end_index=4,
+        )
+    ]
+    footer = conversation_module._citation_footer(citations)
+
+    conversation_module._separate_citations_from_result_speech(
+        result,
+        citations,
+        [footer],
+    )
+
+    assert result.response.speech["plain"]["speech"] == (
+        "IANA maintains the reserved domains. Sources: IANA."
+    )
+    assert result.response.card["simple"] == {
+        "title": "Sources",
+        "content": "- IANA — <https://www.iana.org/help/example-domains>",
+    }
+
+
+def test_citation_result_strips_exact_final_turn_footer_after_tool_iteration(
+    conversation_module,
+):
+    class Response:
+        def __init__(self):
+            self.speech = {
+                "plain": {
+                    "speech": (
+                        "The porch light is now on.\n\nSources:\n"
+                        "- Final source — <https://example.com/final>"
+                    )
+                }
+            }
+            self.card = {}
+
+        def async_set_card(self, title, content):
+            self.card["simple"] = {"title": title, "content": content}
+
+    result = type("Result", (), {"response": Response()})()
+    first_turn = CodexCitation(
+        title="First source",
+        url="https://example.com/first",
+        start_index=0,
+        end_index=4,
+    )
+    final_turn = CodexCitation(
+        title="Final source",
+        url="https://example.com/final",
+        start_index=0,
+        end_index=4,
+    )
+
+    conversation_module._separate_citations_from_result_speech(
+        result,
+        [first_turn, final_turn],
+        [
+            conversation_module._citation_footer([first_turn]),
+            conversation_module._citation_footer([final_turn]),
+        ],
+    )
+
+    assert result.response.speech["plain"]["speech"] == "The porch light is now on."
+    assert result.response.card["simple"] == {
+        "title": "Sources",
+        "content": (
+            "- First source — <https://example.com/first>\n"
+            "- Final source — <https://example.com/final>"
+        ),
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -13,6 +13,7 @@ from custom_components.codex_assist.codex_client import (
     CodexTextDelta,
     CodexToolCall,
     CodexToolCallDelta,
+    CodexWebSearchStartedDelta,
 )
 from tests.ha_fakes import install_homeassistant_fakes
 
@@ -195,6 +196,26 @@ def test_codex_tools_adds_opt_in_web_search_without_ha_tools(conversation_module
     assert conversation_module._codex_tools_from_chat_log(
         FakeChatLog(), enable_web_search=True
     ) == [{"type": "web_search"}]
+
+
+@pytest.mark.asyncio
+async def test_web_search_start_emits_tts_acknowledgement_before_answer(conversation_module):
+    async def stream():
+        yield CodexWebSearchStartedDelta()
+        yield CodexTextDelta("The current answer follows.")
+
+    deltas = [
+        delta
+        async for delta in conversation_module._codex_stream_to_assistant_deltas(stream())
+    ]
+
+    acknowledgement = conversation_module._WEB_SEARCH_TTS_ACKNOWLEDGEMENT
+    assert len(acknowledgement) > 60
+    assert deltas == [
+        {"role": "assistant"},
+        {"content": acknowledgement},
+        {"content": "The current answer follows."},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -215,6 +215,7 @@ async def test_stream_codex_turn_into_chat_log_calls_chat_log_stream_api(
             "reasoning_effort": "low",
             "reasoning_summary": "auto",
             "text_verbosity": "medium",
+            "text_format": None,
         }
     ]
 
@@ -244,6 +245,76 @@ async def test_codex_input_from_chat_log_translates_image_attachments(
     assert content[1]["type"] == "input_image"
     assert content[1]["image_url"].startswith("data:image/png;base64,")
     assert hass.executor_jobs[0][0] is conversation_module._image_attachments_for_codex
+
+
+def test_image_attachments_rejects_too_many_images(
+    conversation_module,
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setattr(conversation_module, "MAX_IMAGE_ATTACHMENTS", 2)
+    attachments = []
+    for index in range(3):
+        path = tmp_path / f"image-{index}.png"
+        path.write_bytes(b"image")
+        attachments.append(type("Attachment", (), {"mime_type": "image/png", "path": path})())
+
+    with pytest.raises(ValueError, match="at most 2 image attachments"):
+        conversation_module._image_attachments_for_codex(attachments)
+
+
+def test_image_attachments_rejects_aggregate_byte_limit(
+    conversation_module,
+    monkeypatch,
+    tmp_path: Path,
+):
+    monkeypatch.setattr(conversation_module, "MAX_TOTAL_IMAGE_ATTACHMENT_BYTES", 5)
+    attachments = []
+    for index in range(2):
+        path = tmp_path / f"image-{index}.png"
+        path.write_bytes(b"abc")
+        attachments.append(type("Attachment", (), {"mime_type": "image/png", "path": path})())
+
+    with pytest.raises(ValueError, match="total attachment size"):
+        conversation_module._image_attachments_for_codex(attachments)
+
+
+def test_image_attachment_growth_is_read_with_a_hard_bound(
+    conversation_module,
+    monkeypatch,
+):
+    import io
+
+    monkeypatch.setattr(conversation_module, "MAX_IMAGE_ATTACHMENT_BYTES", 5)
+    monkeypatch.setattr(conversation_module, "MAX_TOTAL_IMAGE_ATTACHMENT_BYTES", 5)
+
+    class BoundedReader(io.BytesIO):
+        requested_size: int | None = None
+
+        def read(self, size: int | None = -1):
+            self.requested_size = size
+            return super().read(size)
+
+    reader = BoundedReader(b"unexpectedly large")
+
+    class GrowingPath:
+        def stat(self):
+            return type("Stat", (), {"st_size": 1})()
+
+        def open(self, mode):
+            assert mode == "rb"
+            return reader
+
+    attachment = type(
+        "Attachment",
+        (),
+        {"mime_type": "image/png", "path": GrowingPath()},
+    )()
+
+    with pytest.raises(ValueError, match="per-file size limit"):
+        conversation_module._image_attachments_for_codex([attachment])
+
+    assert reader.requested_size == 6
 
 
 def test_trim_codex_input_items_drops_orphaned_tool_outputs(conversation_module):

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -208,7 +208,7 @@ def test_codex_tools_adds_opt_in_web_search_without_ha_tools(conversation_module
 
 
 @pytest.mark.asyncio
-async def test_codex_stream_appends_deduplicated_safe_citation_footer(conversation_module):
+async def test_codex_stream_captures_citations_without_streaming_urls(conversation_module):
     async def stream():
         yield CodexTextDelta("IANA maintains the reserved domains.")
         citation = CodexCitation(
@@ -240,13 +240,6 @@ async def test_codex_stream_appends_deduplicated_safe_citation_footer(conversati
     assert deltas == [
         {"role": "assistant"},
         {"content": "IANA maintains the reserved domains."},
-        {
-            "content": (
-                "\n\nSources:\n"
-                "- IANA \\[Reserved\\] Domains — "
-                "<https://www.iana.org/help/example-domains>"
-            )
-        },
     ]
     assert captured == [
         CodexCitation(
@@ -258,17 +251,10 @@ async def test_codex_stream_appends_deduplicated_safe_citation_footer(conversati
     ]
 
 
-def test_citation_result_keeps_sources_in_card_but_not_speech(conversation_module):
+def test_citation_result_keeps_sources_in_card_without_changing_speech(conversation_module):
     class Response:
         def __init__(self):
-            self.speech = {
-                "plain": {
-                    "speech": (
-                        "IANA maintains the reserved domains. Sources: IANA.\n\nSources:\n"
-                        "- IANA — <https://www.iana.org/help/example-domains>"
-                    )
-                }
-            }
+            self.speech = {"plain": {"speech": "IANA maintains the reserved domains."}}
             self.card = {}
 
         def async_set_card(self, title, content):
@@ -283,16 +269,11 @@ def test_citation_result_keeps_sources_in_card_but_not_speech(conversation_modul
             end_index=4,
         )
     ]
-    footer = conversation_module._citation_footer(citations)
 
-    conversation_module._separate_citations_from_result_speech(
-        result,
-        citations,
-        [footer],
-    )
+    conversation_module._attach_citations_card(result, citations)
 
     assert result.response.speech["plain"]["speech"] == (
-        "IANA maintains the reserved domains. Sources: IANA."
+        "IANA maintains the reserved domains."
     )
     assert result.response.card["simple"] == {
         "title": "Sources",
@@ -300,55 +281,22 @@ def test_citation_result_keeps_sources_in_card_but_not_speech(conversation_modul
     }
 
 
-def test_citation_result_strips_exact_final_turn_footer_after_tool_iteration(
-    conversation_module,
-):
-    class Response:
-        def __init__(self):
-            self.speech = {
-                "plain": {
-                    "speech": (
-                        "The porch light is now on.\n\nSources:\n"
-                        "- Final source — <https://example.com/final>"
-                    )
-                }
-            }
-            self.card = {}
+def test_web_search_instructions_suppress_spoken_source_urls(conversation_module):
+    chat_log = FakeChatLog([FakeContent(role="system", content="Be concise.")])
 
-        def async_set_card(self, title, content):
-            self.card["simple"] = {"title": title, "content": content}
-
-    result = type("Result", (), {"response": Response()})()
-    first_turn = CodexCitation(
-        title="First source",
-        url="https://example.com/first",
-        start_index=0,
-        end_index=4,
+    assert (
+        conversation_module._instructions_for_turn(
+            chat_log, "fallback", web_search=False
+        )
+        == "Be concise."
     )
-    final_turn = CodexCitation(
-        title="Final source",
-        url="https://example.com/final",
-        start_index=0,
-        end_index=4,
+    instructions = conversation_module._instructions_for_turn(
+        chat_log, "fallback", web_search=True
     )
 
-    conversation_module._separate_citations_from_result_speech(
-        result,
-        [first_turn, final_turn],
-        [
-            conversation_module._citation_footer([first_turn]),
-            conversation_module._citation_footer([final_turn]),
-        ],
-    )
-
-    assert result.response.speech["plain"]["speech"] == "The porch light is now on."
-    assert result.response.card["simple"] == {
-        "title": "Sources",
-        "content": (
-            "- First source — <https://example.com/first>\n"
-            "- Final source — <https://example.com/final>"
-        ),
-    }
+    assert instructions.startswith("Be concise.\n\n")
+    assert "do not include raw URLs" in instructions
+    assert "renders structured citations separately" in instructions
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -13,7 +13,6 @@ from custom_components.codex_assist.codex_client import (
     CodexTextDelta,
     CodexToolCall,
     CodexToolCallDelta,
-    CodexWebSearchStartedDelta,
 )
 from tests.ha_fakes import install_homeassistant_fakes
 
@@ -196,26 +195,6 @@ def test_codex_tools_adds_opt_in_web_search_without_ha_tools(conversation_module
     assert conversation_module._codex_tools_from_chat_log(
         FakeChatLog(), enable_web_search=True
     ) == [{"type": "web_search"}]
-
-
-@pytest.mark.asyncio
-async def test_web_search_start_emits_tts_acknowledgement_before_answer(conversation_module):
-    async def stream():
-        yield CodexWebSearchStartedDelta()
-        yield CodexTextDelta("The current answer follows.")
-
-    deltas = [
-        delta
-        async for delta in conversation_module._codex_stream_to_assistant_deltas(stream())
-    ]
-
-    acknowledgement = conversation_module._WEB_SEARCH_TTS_ACKNOWLEDGEMENT
-    assert len(acknowledgement) > 60
-    assert deltas == [
-        {"role": "assistant"},
-        {"content": acknowledgement},
-        {"content": "The current answer follows."},
-    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_behavior.py
+++ b/tests/test_conversation_behavior.py
@@ -5,6 +5,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+import httpx
 import pytest
 
 from custom_components.codex_assist.codex_client import (
@@ -76,6 +77,15 @@ def conversation_module(monkeypatch):
     install_homeassistant_fakes(monkeypatch)
     module = importlib.import_module("custom_components.codex_assist.conversation")
     return importlib.reload(module)
+
+
+def test_request_failure_text_names_blank_transport_error(conversation_module):
+    assert conversation_module._request_failure_text(httpx.ReadTimeout("")) == (
+        "Codex Assist failed: ReadTimeout"
+    )
+    assert conversation_module._request_failure_text(RuntimeError("backend failed")) == (
+        "Codex Assist failed: backend failed"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_runtime_behavior.py
+++ b/tests/test_conversation_runtime_behavior.py
@@ -21,12 +21,17 @@ class FakeConfigEntries:
 
     def async_update_entry(self, entry, *, data):
         self.updates.append((entry, data))
+        entry.data = data
 
 
 class FakeEntry:
     def __init__(self):
         self.entry_id = "entry-1"
-        self.data = {"model": "gpt-5.4", "access_token": "access-1"}
+        self.data = {
+            "model": "gpt-5.4",
+            "access_token": "access-1",
+            "refresh_token": "refresh-1",
+        }
         self.reauth_started = False
 
     def async_start_reauth(self, hass):
@@ -127,7 +132,16 @@ async def test_handle_message_reports_temporary_auth_failure_without_reauth(
     entity = conversation_module.CodexAssistConversationEntity(entry)
     entity.hass = hass
     chat_log = FakeHandleMessageChatLog()
-    monkeypatch.setattr(conversation_module, "resolve_runtime_tokens", fail_temporarily)
+
+    class FailingCoordinator:
+        async def resolve(self, *args, **kwargs):
+            return await fail_temporarily()
+
+    monkeypatch.setattr(
+        conversation_module,
+        "runtime_token_coordinator",
+        lambda entry: FailingCoordinator(),
+    )
 
     result = await entity._async_handle_message(FakeUserInput(), chat_log)
 
@@ -159,7 +173,16 @@ async def test_handle_message_reports_friendly_usage_limit_without_status_code(
     entity.hass = hass
     entity.entity_id = "conversation.codex_assist"
     chat_log = FakeHandleMessageChatLog()
-    monkeypatch.setattr(conversation_module, "resolve_runtime_tokens", resolve_tokens)
+
+    class ResolvedCoordinator:
+        async def resolve(self, *args, **kwargs):
+            return await resolve_tokens()
+
+    monkeypatch.setattr(
+        conversation_module,
+        "runtime_token_coordinator",
+        lambda entry: ResolvedCoordinator(),
+    )
     monkeypatch.setattr(
         conversation_module,
         "_stream_codex_turn_into_chat_log",

--- a/tests/test_web_search_contract_probe.py
+++ b/tests/test_web_search_contract_probe.py
@@ -23,10 +23,12 @@ def test_probe_payload_is_fixed_and_data_minimized() -> None:
     assert payload["tools"] == [
         {
             "type": "web_search",
+            "external_web_access": True,
             "filters": {"allowed_domains": ["iana.org"]},
             "search_context_size": "low",
         }
     ]
+    assert payload["include"] == ["web_search_call.action.sources"]
     assert payload["store"] is False
     assert all("attachments" not in item for item in payload["input"])
     assert all("entity_id" not in item for item in payload["input"])

--- a/tests/test_web_search_contract_probe.py
+++ b/tests/test_web_search_contract_probe.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _probe_module():
+    path = Path(__file__).parents[1] / "scripts" / "probe_web_search_contract.py"
+    spec = importlib.util.spec_from_file_location("probe_web_search_contract", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_probe_payload_is_fixed_and_data_minimized() -> None:
+    module = _probe_module()
+
+    payload = module.probe_payload("gpt-test")
+
+    assert payload["model"] == "gpt-test"
+    assert payload["tools"] == [
+        {
+            "type": "web_search",
+            "filters": {"allowed_domains": ["iana.org"]},
+            "search_context_size": "low",
+        }
+    ]
+    assert payload["store"] is False
+    assert all("attachments" not in item for item in payload["input"])
+    assert all("entity_id" not in item for item in payload["input"])
+
+
+def test_event_summary_preserves_shape_without_text_queries_urls_or_ids() -> None:
+    module = _probe_module()
+    event = {
+        "type": "response.output_item.done",
+        "item_id": "private-item-id",
+        "item": {
+            "type": "web_search_call",
+            "status": "completed",
+            "id": "private-call-id",
+            "action": {
+                "type": "search",
+                "query": "private search query",
+                "sources": [{"type": "url", "url": "https://example.invalid/private"}],
+            },
+        },
+        "delta": "private response text",
+        "annotation": {
+            "type": "url_citation",
+            "url": "https://example.invalid/private",
+            "title": "Private title",
+            "start_index": 0,
+            "end_index": 4,
+        },
+    }
+
+    summary = module.summarize_event(event)
+    rendered = json.dumps(summary)
+
+    assert summary["type"] == "response.output_item.done"
+    assert summary["item"]["type"] == "web_search_call"
+    assert summary["item"]["action"]["type"] == "search"
+    assert summary["annotation"]["type"] == "url_citation"
+    assert summary["delta_length"] == len("private response text")
+    assert "private" not in rendered
+    assert "example.invalid" not in rendered
+    assert "private-item-id" not in rendered

--- a/tests_ha/test_smoke.py
+++ b/tests_ha/test_smoke.py
@@ -8,14 +8,19 @@ calls are stubbed.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+import voluptuous as vol
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.codex_assist import DOMAIN
+from custom_components.codex_assist.ai_task import _structured_output_format
 from custom_components.codex_assist.codex_client import CodexClient, CodexTextDelta
 from custom_components.codex_assist.diagnostics import (
     REDACTED,
@@ -103,3 +108,55 @@ async def test_diagnostics_redact_tokens_on_real_entry(hass: HomeAssistant) -> N
     assert entry_data["refresh_token"] == REDACTED
     assert entry_data["model"] == "gpt-5.4"
     assert "test-access-token" not in str(diagnostics)
+
+
+async def test_options_flow_uses_real_home_assistant_contract(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = await _setup_entry(hass)
+
+    async def fake_model_ids(**kwargs: object) -> list[str]:
+        return ["gpt-5.4"]
+
+    monkeypatch.setattr(
+        "custom_components.codex_assist.config_flow.fetch_codex_model_ids",
+        fake_model_ids,
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "model": "gpt-5.4",
+            "prompt": "Keep it short.",
+            "reasoning_effort": "low",
+            "reasoning_summary": "auto",
+            "text_verbosity": "low",
+            "image_model": "gpt-image-2-medium",
+            "image_size": "1024x1024",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["text_verbosity"] == "low"
+    assert entry.options["prompt"] == "Keep it short."
+
+
+def test_structured_output_uses_real_home_assistant_schema_converter() -> None:
+    task = SimpleNamespace(
+        name="Porch state",
+        structure=vol.Schema({vol.Required("state"): vol.In(["on", "off"])}),
+    )
+    chat_log = SimpleNamespace(llm_api=None)
+
+    text_format = _structured_output_format(task, chat_log)
+
+    assert text_format is not None
+    assert text_format["type"] == "json_schema"
+    assert text_format["name"] == "porch_state"
+    assert text_format["schema"]["required"] == ["state"]
+    assert text_format["schema"]["properties"]["state"]["enum"] == ["on", "off"]

--- a/tests_ha/test_smoke.py
+++ b/tests_ha/test_smoke.py
@@ -16,12 +16,20 @@ from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import llm
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.codex_assist import DOMAIN
 from custom_components.codex_assist.ai_task import _structured_output_format
-from custom_components.codex_assist.codex_client import CodexClient, CodexTextDelta
+from custom_components.codex_assist.codex_client import (
+    CodexCitation,
+    CodexCitationDelta,
+    CodexClient,
+    CodexTextDelta,
+    CodexToolCall,
+    CodexToolCallDelta,
+)
 from custom_components.codex_assist.diagnostics import (
     REDACTED,
     async_get_config_entry_diagnostics,
@@ -98,6 +106,127 @@ async def test_conversation_turn_streams_codex_reply(
     assert speech == "The porch light is on."
 
 
+async def test_web_search_citations_are_displayable_but_not_spoken(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = await _setup_entry(hass)
+    hass.config_entries.async_update_entry(entry, options={"web_search": True})
+
+    async def fake_stream_turn(self: CodexClient, **kwargs: object):
+        tools = kwargs["tools"]
+        assert isinstance(tools, list)
+        assert {"type": "web_search"} in tools
+        yield CodexTextDelta("IANA maintains the reserved domains.")
+        yield CodexCitationDelta(
+            CodexCitation(
+                title="IANA Reserved Domains",
+                url="https://www.iana.org/help/example-domains",
+                start_index=0,
+                end_index=4,
+            )
+        )
+
+    monkeypatch.setattr(CodexClient, "stream_turn", fake_stream_turn)
+
+    result = await conversation.async_converse(
+        hass,
+        "Who maintains the reserved domains?",
+        None,
+        Context(),
+        agent_id="conversation.codex_assist",
+    )
+
+    assert result.response.speech["plain"]["speech"] == ("IANA maintains the reserved domains.")
+    assert result.response.card["simple"] == {
+        "title": "Sources",
+        "content": ("- IANA Reserved Domains — <https://www.iana.org/help/example-domains>"),
+    }
+
+
+async def test_multi_turn_web_search_sources_are_not_spoken_after_ha_tool_call(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = await _setup_entry(hass)
+    hass.config_entries.async_update_entry(entry, options={"web_search": True})
+
+    fake_tool = SimpleNamespace(
+        name="HassTestTool",
+        description="A harmless test tool",
+        parameters=vol.Schema({}),
+    )
+
+    class FakeApiInstance:
+        api_prompt = "A harmless test tool is available."
+        tools = [fake_tool]
+        custom_serializer = None
+
+        async def async_call_tool(self, tool_input: llm.ToolInput) -> dict[str, bool]:
+            assert tool_input.tool_name == "HassTestTool"
+            return {"success": True}
+
+    async def fake_get_api(*args: object, **kwargs: object) -> FakeApiInstance:
+        return FakeApiInstance()
+
+    monkeypatch.setattr(llm, "async_get_api", fake_get_api)
+
+    call_count = 0
+
+    async def fake_stream_turn(self: CodexClient, **kwargs: object):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            yield CodexTextDelta("I found the background information.")
+            yield CodexCitationDelta(
+                CodexCitation(
+                    title="Background source",
+                    url="https://example.com/background",
+                    start_index=0,
+                    end_index=4,
+                )
+            )
+            yield CodexToolCallDelta(
+                CodexToolCall(
+                    id="call-1",
+                    name="HassTestTool",
+                    arguments={},
+                )
+            )
+            return
+        yield CodexTextDelta("The harmless tool completed successfully.")
+        yield CodexCitationDelta(
+            CodexCitation(
+                title="Final source",
+                url="https://example.com/final",
+                start_index=0,
+                end_index=4,
+            )
+        )
+
+    monkeypatch.setattr(CodexClient, "stream_turn", fake_stream_turn)
+
+    result = await conversation.async_converse(
+        hass,
+        "Research this and use the harmless tool.",
+        None,
+        Context(),
+        agent_id="conversation.codex_assist",
+    )
+
+    assert call_count == 2
+    assert result.response.speech["plain"]["speech"] == (
+        "The harmless tool completed successfully."
+    )
+    assert result.response.card["simple"] == {
+        "title": "Sources",
+        "content": (
+            "- Background source — <https://example.com/background>\n"
+            "- Final source — <https://example.com/final>"
+        ),
+    }
+
+
 async def test_diagnostics_redact_tokens_on_real_entry(hass: HomeAssistant) -> None:
     entry = await _setup_entry(hass)
 
@@ -136,6 +265,7 @@ async def test_options_flow_uses_real_home_assistant_contract(
             "reasoning_effort": "low",
             "reasoning_summary": "auto",
             "text_verbosity": "low",
+            "web_search": True,
             "image_model": "gpt-image-2-medium",
             "image_size": "1024x1024",
         },
@@ -143,6 +273,7 @@ async def test_options_flow_uses_real_home_assistant_contract(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["text_verbosity"] == "low"
+    assert result["data"]["web_search"] is True
     assert entry.options["prompt"] == "Keep it short."
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.3.2"
+version = "0.4.0b1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.0b1"
+version = "0.4.0b3"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,7 @@ version = "0.4.0b1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "voluptuous-openapi" },
 ]
 
 [package.optional-dependencies]
@@ -63,6 +64,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
+    { name = "voluptuous-openapi", specifier = ">=0.3,<0.5" },
 ]
 provides-extras = ["dev"]
 
@@ -200,4 +202,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "voluptuous"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/f4/0738e6849858deae22218be3bbb8207ba83a96e9d0ec7e8e8cd67b30e5ca/voluptuous-0.16.0.tar.gz", hash = "sha256:006535e22fed944aec17bef6e8725472476194743c87bd233e912eb463f8ff05", size = 54238, upload-time = "2025-12-18T23:18:46.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl", hash = "sha256:ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4", size = 31931, upload-time = "2025-12-18T23:18:44.694Z" },
+]
+
+[[package]]
+name = "voluptuous-openapi"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "voluptuous" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/a5/517c143607fd82cfc8842fcdccf5cf2c07cdd96528c936bde196e05dece3/voluptuous_openapi-0.4.1.tar.gz", hash = "sha256:745d0d60940a851d9a90c87eebf659c57072c9ef305c0f6f04f4fd7c063dc0ac", size = 21432, upload-time = "2026-06-26T13:31:35.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/bb/64db054ad3852e3b63841a570942d3ce29e6b44979d5ac4be806973a2338/voluptuous_openapi-0.4.1-py3-none-any.whl", hash = "sha256:b30abc527c622cd62dba1269a05099e6b6170678c2838908d347fa85ab0cdb44", size = 12824, upload-time = "2026-06-26T13:31:35.126Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.0b3"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- add default-off hosted Codex web search for Assist and unstructured AI Tasks
- preserve validated citations for display while excluding generated source footers from TTS
- harden stream failures, structured AI Tasks, attachment limits, and refresh-token concurrency before expanding the tool surface
- test current and minimum-supported Home Assistant contracts

## Verification

- `uv run pytest -q` — 105 passed
- latest Home Assistant contract suite — 8 passed
- Home Assistant 2026.5.0 contract suite — 8 passed
- Ruff lint and touched-file format checks passed
- lockfile, compilation, diff, and icon transparency checks passed
- independent focused review completed; multi-turn citation/TTS finding fixed with real-HA regression

## Beta caveat

The private Codex Responses endpoint has not yet been live-probed with an integration-owned OAuth grant. This draft PR exists to validate the exact beta candidate in CI and support a controlled HACS prerelease smoke test before merge.

## Acknowledgment

Web-search support was inspired in part by early experimentation in [greimela/ha-codex-assist](https://github.com/greimela/ha-codex-assist), particularly the opt-in search and citation-free TTS concepts. This repository’s implementation was developed independently and substantially expanded with structured citation handling, validation, and compatibility coverage.
