### PR TITLE
Keep compatibility pins out of Dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,25 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      python-runtime:
+        patterns:
+          - "*"
+    # These define the oldest/current Home Assistant contract lanes and must be
+    # advanced together with docs and real-HA tests, not as independent bumps.
+    ignore:
+      - dependency-name: homeassistant
+      - dependency-name: pytest-homeassistant-custom-component
+      - dependency-name: hassil
+      - dependency-name: home-assistant-intents
+      - dependency-name: PyTurboJPEG
+      - dependency-name: voluptuous-openapi
+      - dependency-name: gazetteer-matcher
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      ci-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Dependabot's first post-v0.4.1 run tried to update each pinned Home Assistant compatibility dependency independently, including replacing the minimum 2026.6 lane with 2026.8.

This keeps the intentionally coordinated Home Assistant contract packages out of automated version bumps while retaining grouped updates for ordinary Python runtime dependencies and CI actions.

## Verification

- Dependabot YAML parsed successfully
- `uv run ruff check .`
- `uv run pytest -q` — 112 passed
- `git diff --check`
