### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.1"
+version = "0.4.2"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.1"
+version = "0.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump the integration and project version to 0.4.2
- refresh the lockfile version metadata
- prepare the verified settings UX and documentation changes for HACS installation

## Verification
- `uv run ruff check .`
- `uv run pytest -q` — 115 passed
- Home Assistant 2026.6 contract tests — 8 passed
- Home Assistant stable contract tests — 8 passed
- `uv lock --check`
- `git diff --check`
