### PR TITLE
Prepare v0.4.3-rc.1 prerelease

### DIFF
--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.2"
+  "version": "0.4.3-rc.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.2"
+version = "0.4.3-rc.1"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.2"
+version = "0.4.3rc1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare Codex Assist `v0.4.3-rc.1` for installed Home Assistant acceptance testing. The integration manifest, Python package metadata, and lockfile identify the build as a prerelease.

## Included changes

This release candidate includes the changes merged since `v0.4.2`:

- Fix structured AI Tasks that use Home Assistant selectors without an attached LLM API.
- Support OpenAI strict schemas without breaking optional, default, nullable, nested, or composed Home Assistant fields.
- Return a final answer when an Assist tool loop reaches its round limit.
- Keep native Codex response state between turns instead of rebuilding it from displayed text.
- Redact retained response state from normal logs, listeners, and conversation traces.
- Add a multiline system-prompt editor for longer Markdown instructions.
- Refresh the settings screenshot and related documentation.

## Attribution

@mattrossman contributed the selector fallback, strict schema generation, and original regression coverage for structured AI Tasks. A follow-up compatibility fix preserves Home Assistant's optional and nullable field behavior under strict mode.

## Verification

Exact head: `efdd0af8cb6eba34a545f8a5ee63993fa831d2ba`

- `uv lock --check`
- `uv run ruff check .`
- `uv run pytest -q`
- Home Assistant 2026.8 contract suite
- Home Assistant 2026.6 minimum contract suite
- Version metadata alignment
- Brand icon transparency checks
- `git diff --check`
- Independent review found no blocking issues
- All five hosted checks passed on the exact head

Publishing the prerelease remains separate from this pull request. Stable `v0.4.3` will require an installed Home Assistant smoke test and a separate stable version pull request.
