### PR TITLE
Prepare v0.4.3 release

### DIFF
--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.3-rc.1"
+  "version": "0.4.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.3-rc.1"
+version = "0.4.3"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.3rc1"
+version = "0.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Prepare Codex Assist `v0.4.3` by updating the integration manifest, Python package metadata, and lockfile version.

## Included changes

This maintenance release includes the changes merged since `v0.4.2`:

- Fix structured AI Tasks that use Home Assistant selectors without an attached LLM API.
- Support OpenAI strict schemas without breaking optional, default, nullable, nested, or composed Home Assistant fields.
- Return a final answer when an Assist tool loop reaches its round limit.
- Keep native Codex response state between turns instead of rebuilding it from displayed text.
- Redact retained response state from normal logs, listeners, and conversation traces.
- Add a multiline system-prompt editor for longer Markdown instructions.
- Refresh the settings screenshot and related documentation.

## Attribution

@mattrossman contributed the selector fallback, strict schema generation, and original regression coverage for structured AI Tasks. A follow-up compatibility fix preserves Home Assistant's optional and nullable field behavior under strict mode.

## Verification

Exact head: `12ed3ed322431c11bc45190e89b733df7b4221a5`

- `uv lock --check`
- `uv run ruff check .`
- `uv run pytest -q` with 135 passing tests
- Home Assistant 2026.8 contract suite with 13 passing tests
- Home Assistant 2026.6 minimum contract suite with 13 passing tests
- Version metadata aligned at `0.4.3`
- Brand icon transparency checks passed
- `git diff --check`
- Installed `v0.4.3-rc.1` acceptance testing passed in Home Assistant
- Independent review found no blocking issues
- All five hosted checks passed on the exact head

Tagging and publication remain separate from this pull request.
