### PR TITLE
Experiment: tolerate quiet Codex response streams

### DIFF
--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -5,6 +5,7 @@ import base64
 import copy
 import json
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -175,13 +176,14 @@ class CodexClient:
             text_format=text_format,
         )
 
-        async with self._http_client.stream(
+        stream_context = self._http_client.stream(
             "POST",
             f"{self._base_url}/responses",
             headers=codex_headers(self._access_token),
             json=payload,
             timeout=CODEX_STREAM_TIMEOUT,
-        ) as response:
+        )
+        async with _response_stream_with_deadline(stream_context) as response:
             if response.status_code != 200:
                 error = await _stream_response_error(response)
                 if response.status_code == 401 or error.code == "token_invalidated":
@@ -197,7 +199,7 @@ class CodexClient:
             pending_tool_calls: dict[str, tuple[dict[str, Any], str]] = {}
             completed_tool_call_ids: set[str] = set()
             anonymous_call_index = 0
-            async for event in _aiter_sse_events_with_deadline(response):
+            async for event in _aiter_sse_events(response):
                 event_type = event.get("type")
                 for citation in _citations_from_event(event):
                     yield CodexCitationDelta(citation)
@@ -815,14 +817,16 @@ async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:
         yield payload
 
 
-async def _aiter_sse_events_with_deadline(
-    response: Any,
-) -> AsyncIterator[dict[str, Any]]:
+@asynccontextmanager
+async def _response_stream_with_deadline(stream_context: Any) -> AsyncIterator[Any]:
+    deadline = asyncio.timeout(CODEX_STREAM_DEADLINE)
     try:
-        async with asyncio.timeout(CODEX_STREAM_DEADLINE):
-            async for event in _aiter_sse_events(response):
-                yield event
+        async with deadline:
+            async with stream_context as response:
+                yield response
     except TimeoutError as err:
+        if not deadline.expired():
+            raise
         raise CodexStreamTimeoutError(
             f"Codex response stream exceeded {CODEX_STREAM_DEADLINE} seconds"
         ) from err

--- a/custom_components/codex_assist/codex_client.py
+++ b/custom_components/codex_assist/codex_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import copy
 import json
@@ -7,10 +8,13 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, Protocol
 
+import httpx
+
 from .codex_image import image_model_quality, validate_image_size
 
 CODEX_BACKEND_BASE_URL = "https://chatgpt.com/backend-api/codex"
-CODEX_STREAM_TIMEOUT = 300
+CODEX_STREAM_DEADLINE = 15 * 60
+CODEX_STREAM_TIMEOUT = httpx.Timeout(connect=10, read=None, write=30, pool=10)
 
 
 class AsyncPostClient(Protocol):
@@ -77,6 +81,10 @@ class CodexResponseItemDelta:
 CodexStreamDelta = (
     CodexTextDelta | CodexToolCallDelta | CodexCitationDelta | CodexResponseItemDelta
 )
+
+
+class CodexStreamTimeoutError(RuntimeError):
+    """Raised when a complete Codex response stream exceeds its deadline."""
 
 
 class CodexClient:
@@ -189,7 +197,7 @@ class CodexClient:
             pending_tool_calls: dict[str, tuple[dict[str, Any], str]] = {}
             completed_tool_call_ids: set[str] = set()
             anonymous_call_index = 0
-            async for event in _aiter_sse_events(response):
+            async for event in _aiter_sse_events_with_deadline(response):
                 event_type = event.get("type")
                 for citation in _citations_from_event(event):
                     yield CodexCitationDelta(citation)
@@ -805,6 +813,19 @@ async def _aiter_sse_events(response: Any) -> AsyncIterator[dict[str, Any]]:
     payload = _parse_sse_payload(data_lines, event_name)
     if payload is not None:
         yield payload
+
+
+async def _aiter_sse_events_with_deadline(
+    response: Any,
+) -> AsyncIterator[dict[str, Any]]:
+    try:
+        async with asyncio.timeout(CODEX_STREAM_DEADLINE):
+            async for event in _aiter_sse_events(response):
+                yield event
+    except TimeoutError as err:
+        raise CodexStreamTimeoutError(
+            f"Codex response stream exceeded {CODEX_STREAM_DEADLINE} seconds"
+        ) from err
 
 
 def _parse_sse_payload(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,7 +31,7 @@ flowchart LR
 - **Conversation agent** registers `conversation.codex_assist` for Home Assistant Assist pipelines.
 - **AI Task entity** registers a native provider for text, structured data, supported image attachments, and image generation.
 - **Runtime token coordinator** serializes refresh-token rotation per config entry. Concurrent Conversation and AI Task requests reuse the winning refresh instead of invalidating one another.
-- **Codex client** sends requests to the Codex-compatible service interface and normalizes its response stream.
+- **Codex client** sends requests to the Codex-compatible service interface and normalizes its response stream. Response streams allow quiet reasoning periods without an idle-read cutoff, while a response-stream deadline still bounds abandoned requests.
 - **Native transcript state** retains completed provider output items for stateless replay. The state is deep-copy isolated and remains opaque to normal Home Assistant logs, listeners, and conversation traces, which receive only redacted metadata.
 - **Hosted web search** is an explicit option. When enabled, it adds the backend `web_search` tool and converts structured URL annotations into a validated source card. Unsupported or unsafe citation URLs are discarded.
 - **Assist tool bridge** maps model-requested device actions into Home Assistant's Assist LLM API. It does not call services directly.

--- a/tests/test_codex_client_image_generation.py
+++ b/tests/test_codex_client_image_generation.py
@@ -99,6 +99,7 @@ async def test_generate_image_uses_codex_responses_image_generation_tool():
     assert method == "POST"
     assert url == "https://chatgpt.com/backend-api/codex/responses"
     assert kwargs["headers"]["Accept"] == "text/event-stream"
+    assert kwargs["timeout"] == 300
     assert payload["model"] == "gpt-5.4"
     assert payload["stream"] is True
     assert payload["tools"] == [

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -1,13 +1,17 @@
+import asyncio
 import json
 
 import pytest
 
+from custom_components.codex_assist import codex_client as codex_client_module
 from custom_components.codex_assist.codex_client import (
+    CODEX_STREAM_DEADLINE,
     CODEX_STREAM_TIMEOUT,
     CodexCitationDelta,
     CodexClient,
     CodexRateLimitError,
     CodexResponseItemDelta,
+    CodexStreamTimeoutError,
     CodexTextDelta,
     CodexToolCallDelta,
 )
@@ -46,6 +50,17 @@ class FakeHttpClient:
         return self.response
 
 
+class BlockingStreamResponse(FakeStreamResponse):
+    def __init__(self):
+        super().__init__(200, [])
+        self.started = asyncio.Event()
+
+    async def aiter_lines(self):
+        self.started.set()
+        await asyncio.Event().wait()
+        yield  # pragma: no cover
+
+
 def _event(payload):
     return ["data: " + json.dumps(payload), ""]
 
@@ -81,6 +96,50 @@ async def test_stream_turn_yields_text_deltas_and_posts_advanced_options():
     assert payload["include"] == ["reasoning.encrypted_content"]
     assert payload["text"] == {"verbosity": "low"}
     assert http.calls[0][2]["timeout"] == CODEX_STREAM_TIMEOUT
+
+
+def test_stream_timeout_allows_quiet_reads_but_bounds_connection_operations():
+    assert CODEX_STREAM_TIMEOUT.connect == 10
+    assert CODEX_STREAM_TIMEOUT.read is None
+    assert CODEX_STREAM_TIMEOUT.write == 30
+    assert CODEX_STREAM_TIMEOUT.pool == 10
+    assert CODEX_STREAM_DEADLINE == 15 * 60
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_enforces_response_stream_deadline(monkeypatch):
+    response = BlockingStreamResponse()
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+    monkeypatch.setattr(codex_client_module, "CODEX_STREAM_DEADLINE", 0.01)
+
+    with pytest.raises(CodexStreamTimeoutError, match="exceeded 0.01 seconds"):
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Think carefully.",
+            input_items=[{"role": "user", "content": "hard question"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_preserves_caller_cancellation():
+    response = BlockingStreamResponse()
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+
+    async def consume_stream():
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Think carefully.",
+            input_items=[{"role": "user", "content": "hard question"}],
+        ):
+            pass
+
+    task = asyncio.create_task(consume_stream())
+    await response.started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio

--- a/tests/test_codex_client_stream_turn.py
+++ b/tests/test_codex_client_stream_turn.py
@@ -61,6 +61,24 @@ class BlockingStreamResponse(FakeStreamResponse):
         yield  # pragma: no cover
 
 
+class BlockingStreamContext:
+    def __init__(self):
+        self.started = asyncio.Event()
+
+    async def __aenter__(self):
+        self.started.set()
+        await asyncio.Event().wait()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+class BuiltinTimeoutStreamResponse(FakeStreamResponse):
+    async def aiter_lines(self):
+        raise TimeoutError("synthetic iterator timeout")
+        yield  # pragma: no cover
+
+
 def _event(payload):
     return ["data: " + json.dumps(payload), ""]
 
@@ -107,12 +125,46 @@ def test_stream_timeout_allows_quiet_reads_but_bounds_connection_operations():
 
 
 @pytest.mark.asyncio
-async def test_stream_turn_enforces_response_stream_deadline(monkeypatch):
+async def test_stream_turn_enforces_deadline_after_response_headers(monkeypatch):
     response = BlockingStreamResponse()
     client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
     monkeypatch.setattr(codex_client_module, "CODEX_STREAM_DEADLINE", 0.01)
 
     with pytest.raises(CodexStreamTimeoutError, match="exceeded 0.01 seconds"):
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Think carefully.",
+            input_items=[{"role": "user", "content": "hard question"}],
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_enforces_deadline_before_response_headers(monkeypatch):
+    stream_context = BlockingStreamContext()
+    client = CodexClient(
+        http_client=FakeHttpClient(stream_context),
+        access_token="token-1",
+    )
+    monkeypatch.setattr(codex_client_module, "CODEX_STREAM_DEADLINE", 0.01)
+
+    with pytest.raises(CodexStreamTimeoutError, match="exceeded 0.01 seconds"):
+        async for _delta in client.stream_turn(
+            model="gpt-5.4",
+            instructions="Think carefully.",
+            input_items=[{"role": "user", "content": "hard question"}],
+        ):
+            pass
+
+    assert stream_context.started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stream_turn_preserves_unrelated_builtin_timeout():
+    response = BuiltinTimeoutStreamResponse(200, [])
+    client = CodexClient(http_client=FakeHttpClient(response), access_token="token-1")
+
+    with pytest.raises(TimeoutError, match="synthetic iterator timeout"):
         async for _delta in client.stream_turn(
             model="gpt-5.4",
             instructions="Think carefully.",


### PR DESCRIPTION
## Experiment question

Can Codex Assist tolerate long, quiet reasoning periods without leaving abandoned response streams unbounded?

This is a disposable experiment inspired by Maeriberii's unbounded SSE read-timeout change: https://github.com/Maeriberii/ha-codex-assist/commit/1f3be06

## What this changes

- removes the per-read timeout from streamed text responses so a healthy stream may remain quiet while Codex reasons;
- keeps connect, write, and connection-pool operations bounded;
- adds a 15-minute deadline around the complete streamed request, including the response-header wait;
- preserves caller cancellation as `CancelledError`;
- leaves image-generation timeout behavior unchanged.

The timeout policy remains maintainer-owned. This PR intentionally adds no user-facing runtime settings.

## What we need to evaluate

- whether the current 300-second read timeout has caused or can reproduce real failures;
- whether 15 minutes is an appropriate response-stream deadline;
- whether a total deadline should reset on progress instead;
- whether the reliability benefit justifies changing the current stable behavior.

Scrapping this experiment is an acceptable outcome if live evidence does not justify it.

## Verification

Exact local head: `74b6e4e`

- `uv run --frozen ruff check .`
- `uv run --frozen pytest -q` -> 140 passed
- HA 2026.8.3 contract lane -> 13 passed
- HA 2026.6.0 minimum contract lane -> 13 passed
- focused stream and image suites -> 20 passed
- `git diff --check`

The first independent review found a pre-header deadline gap and overly broad timeout translation. Both are fixed at this head with regressions. Independent exact-head rereview is in progress. This draft should not be merged until that review and any live evaluation are complete.
