### PR TITLE
Support Home Assistant 2026.9 schema conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,36 @@ jobs:
       - name: Run contract tests against minimum Home Assistant
         run: python -m pytest tests_ha -q
 
+      - name: Install Probatio alongside the legacy converter
+        run: pip install probatio==0.11.2
+
+      - name: Verify minimum Home Assistant with both converters installed
+        run: python -m pytest tests_ha -q
+
+  ha-previous:
+    name: Home Assistant 2026.8 contract tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Install previous Home Assistant test environment
+        run: pip install -r requirements_test_ha_previous.txt
+
+      - name: Verify previous Home Assistant
+        run: python -m pytest tests_ha -q
+
+      - name: Install Probatio alongside the legacy converter
+        run: pip install probatio==0.11.2
+
+      - name: Verify previous Home Assistant with both converters installed
+        run: python -m pytest tests_ha -q
+
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv run ruff check .
 
   ha-smoke:
-    name: Home Assistant 2026.8 stable contract tests
+    name: Home Assistant 2026.9 stable contract tests
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ uv run ruff check .
 uv run pytest -q
 ```
 
-The fast suite under `tests/` uses lightweight Home Assistant fakes. Run both real Home Assistant contract environments in isolated Python 3.14 environments so they do not reuse the project's normal environment:
+The fast suite under `tests/` uses lightweight Home Assistant fakes. Run the real Home Assistant contract environments in isolated Python 3.14 environments so they do not reuse the project's normal environment:
 
 ```bash
 uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt \
@@ -27,6 +27,9 @@ uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt
 uv run --isolated --python 3.14 --with-requirements requirements_test_ha.txt \
   python -m pytest tests_ha -q
 ```
+
+Also run the previous-version and mixed-library checks in [docs/TESTING.md](docs/TESTING.md)
+when changing schema conversion or dependency support.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Requirements: Home Assistant `2026.6.0` or newer, HACS, and a ChatGPT account or
 
 Codex Assist is included in HACS by default. You do not need to add this repository as a custom repository. If it does not appear immediately after a release or catalog change, refresh HACS data and try again later.
 
+Home Assistant 2026.9 changed its schema converter. Codex Assist `0.4.4` fixes
+setup failures mentioning `voluptuous_openapi` and Assist errors mentioning
+`_Unsupported`. Update Codex Assist and restart Home Assistant; existing sign-in
+and settings can be kept. See [Troubleshooting](https://github.com/itsreverence/ha-codex-assist/wiki/Troubleshooting).
+
 ## What it does
 
 ### Assist conversations

--- a/custom_components/codex_assist/ai_task.py
+++ b/custom_components/codex_assist/ai_task.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.util import slugify
 from homeassistant.util.json import json_loads
-from voluptuous_openapi import convert
 
 from .codex_auth import (
     CodexAuthClient,
@@ -47,6 +46,7 @@ from .conversation import (
     _stream_codex_turn_into_chat_log,
 )
 from .error_formatting import request_failure_text
+from .schema_compat import to_openapi
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -431,7 +431,7 @@ def _structured_output_format(
         if chat_log.llm_api is not None
         else llm.selector_serializer
     )
-    schema = copy.deepcopy(convert(task.structure, custom_serializer=custom_serializer))
+    schema = copy.deepcopy(to_openapi(task.structure, custom_serializer=custom_serializer))
     _apply_codex_strict_schema(schema)
     return {
         "type": "json_schema",

--- a/custom_components/codex_assist/conversation.py
+++ b/custom_components/codex_assist/conversation.py
@@ -45,6 +45,7 @@ from .config_flow import (
     DEFAULT_WEB_SEARCH,
 )
 from .error_formatting import request_failure_text
+from .schema_compat import to_openapi
 
 MAX_TOOL_ITERATIONS = 5
 MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024
@@ -643,9 +644,7 @@ def _codex_tool_from_ha_tool(
     tool: llm.Tool,
     custom_serializer: Any,
 ) -> dict[str, Any]:
-    from voluptuous_openapi import convert  # noqa: PLC0415
-
-    schema = convert(tool.parameters, custom_serializer=custom_serializer)
+    schema = to_openapi(tool.parameters, custom_serializer=custom_serializer)
     unsupported_keys = {"oneOf", "anyOf", "allOf", "enum", "not"}
     if unsupported_keys.intersection(schema):
         schema = {k: v for k, v in schema.items() if k not in unsupported_keys}

--- a/custom_components/codex_assist/manifest.json
+++ b/custom_components/codex_assist/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://github.com/itsreverence/ha-codex-assist",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/itsreverence/ha-codex-assist/issues",
-  "version": "0.4.3"
+  "version": "0.4.4"
 }

--- a/custom_components/codex_assist/schema_compat.py
+++ b/custom_components/codex_assist/schema_compat.py
@@ -1,0 +1,8 @@
+"""OpenAPI schema conversion across supported Home Assistant releases."""
+
+try:
+    from probatio import to_openapi
+except ImportError:
+    from voluptuous_openapi import convert as to_openapi
+
+__all__ = ["to_openapi"]

--- a/custom_components/codex_assist/schema_compat.py
+++ b/custom_components/codex_assist/schema_compat.py
@@ -1,8 +1,12 @@
 """OpenAPI schema conversion across supported Home Assistant releases."""
 
+from homeassistant.helpers import llm
+
+# Use the converter paired with HA's serializer and its UNSUPPORTED sentinel.
+# Package availability is insufficient: older HA may also have Probatio installed.
 try:
-    from probatio import to_openapi
-except ImportError:
-    from voluptuous_openapi import convert as to_openapi
+    to_openapi = llm.to_openapi
+except AttributeError:
+    to_openapi = llm.convert
 
 __all__ = ["to_openapi"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,6 +58,15 @@ For stateless multi-turn requests, Codex Assist keeps completed provider output 
 
 Normal Assist conversation surfaces may not expose an upload button even though Home Assistant chat-log objects can carry attachments internally. Use AI Task surfaces that advertise attachment support when testing native attachments.
 
+## Schema conversion compatibility
+
+Assist tool parameters and structured AI Task output use the converter exposed
+by Home Assistant's LLM helper. Home Assistant 2026.9 uses Probatio's
+`to_openapi`; older supported versions use `convert` from voluptuous-openapi.
+The converter must match the helper's serializer and unsupported-value sentinel,
+even when both libraries are installed. Home Assistant supplies the matching
+library; Codex Assist does not install a separate schema converter.
+
 ## Security boundary
 
 Codex or ChatGPT may suggest an action, but Home Assistant remains the execution boundary. Device control goes through Home Assistant's Assist LLM API and is limited to entities exposed to Assist.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,7 +19,7 @@ uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt
 ```
 
 CI runs the fast suite plus pinned real-Home-Assistant contract lanes against
-Home Assistant 2026.8.3 and Home Assistant 2026.6.0, the minimum supported
+Home Assistant 2026.9.0 and Home Assistant 2026.6.0, the minimum supported
 version. Update the stable pins in `requirements_test_ha.txt` together when
 advancing that contract. Both lanes also run weekly to catch regressions without
 silently resolving a prerelease or a newly incompatible test harness mid-run.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,10 +19,26 @@ uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt
 ```
 
 CI runs the fast suite plus pinned real-Home-Assistant contract lanes against
-Home Assistant 2026.9.0 and Home Assistant 2026.6.0, the minimum supported
-version. Update the stable pins in `requirements_test_ha.txt` together when
-advancing that contract. Both lanes also run weekly to catch regressions without
+Home Assistant 2026.9.0, Home Assistant 2026.8.3 (before the schema converter
+transition), and Home Assistant 2026.6.0, the minimum supported version. Update the stable pins in `requirements_test_ha.txt` together when
+advancing that contract. All lanes also run weekly to catch regressions without
 silently resolving a prerelease or a newly incompatible test harness mid-run.
+
+The older lanes also run with `probatio==0.11.2` installed alongside
+`voluptuous-openapi`. This catches converter/serializer mismatches when both
+packages are available. Codex Assist selects the converter used by Home
+Assistant's LLM helper, rather than inferring it from installed packages.
+
+```bash
+uv run --isolated --python 3.14 --with-requirements requirements_test_ha_previous.txt \
+  python -m pytest tests_ha -q
+
+uv run --isolated --python 3.14 --with-requirements requirements_test_ha_min.txt \
+  --with probatio==0.11.2 python -m pytest tests_ha -q
+
+uv run --isolated --python 3.14 --with-requirements requirements_test_ha_previous.txt \
+  --with probatio==0.11.2 python -m pytest tests_ha -q
+```
 
 ## Hosted-search compatibility
 

--- a/docs/releases/0.4.4.md
+++ b/docs/releases/0.4.4.md
@@ -22,6 +22,9 @@ converter selection and regression coverage.
 
 Validation: Ruff, 137 unit tests, and 13 contract tests in each of five isolated
 environments: HA 2026.6.0, 2026.8.3, and 2026.9.0, plus both older versions with
-Probatio also installed. The contributor reports live Assist and structured
-AI Task testing; maintainer verification for this release was automated and
-did not include an independent live-instance smoke test.
+Probatio also installed. Maintainer live checks on HA 2026.9.0 also verified startup, text
+conversation, a native read-only Assist tool call, a follow-up turn, and structured
+AI Task output with required and optional fields. These checks used an available
+model from authenticated discovery. No device state changes were made during
+maintainer testing. The contributor also reports live Assist and structured AI
+Task testing.

--- a/docs/releases/0.4.4.md
+++ b/docs/releases/0.4.4.md
@@ -1,0 +1,27 @@
+# Codex Assist 0.4.4
+
+Fixes setup and Assist tool failures after upgrading to Home Assistant 2026.9.
+Home Assistant changed its schema converter, causing `No module named
+'voluptuous_openapi'` during setup and `'_Unsupported' object is not iterable`
+when using the old converter with the new serializer.
+
+Both Assist tools and structured AI Tasks now use the converter paired with
+Home Assistant's serializer. Home Assistant 2026.6.0 remains supported, including
+installations where both schema libraries are present.
+
+Update through HACS and restart Home Assistant Core. Existing sign-in and
+settings can be kept. If you edited the manifest as a workaround, redownload
+the integration to restore the release files before restarting.
+
+Thanks to Gregory Grubbs (@gregoryg) for the original compatibility fix in
+[PR #32](https://github.com/itsreverence/ha-codex-assist/pull/32), to @mattrossman
+for confirming it on a live Home Assistant 2026.9 installation, and to the
+reporters and testers in [issue #33](https://github.com/itsreverence/ha-codex-assist/issues/33).
+Gregory's original commit is retained, with a separate maintainer follow-up for
+converter selection and regression coverage.
+
+Validation: Ruff, 137 unit tests, and 13 contract tests in each of five isolated
+environments: HA 2026.6.0, 2026.8.3, and 2026.9.0, plus both older versions with
+Probatio also installed. The contributor reports live Assist and structured
+AI Task testing; maintainer verification for this release was automated and
+did not include an independent live-instance smoke test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ license = { text = "MIT" }
 authors = [{ name = "Codex Assist contributors" }]
 dependencies = [
   "httpx>=0.27",
-  "voluptuous-openapi>=0.3,<0.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ha-codex-assist"
-version = "0.4.3"
+version = "0.4.4"
 description = "Home Assistant Assist conversation agent backed by OpenAI Codex OAuth"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/requirements_test_ha.txt
+++ b/requirements_test_ha.txt
@@ -1,14 +1,11 @@
 # Current stable Home Assistant contract (Python 3.14+).
 # Update these pins together when advancing the supported stable contract.
-homeassistant==2026.8.3
-pytest-homeassistant-custom-component==0.13.357
+homeassistant==2026.9.0
+pytest-homeassistant-custom-component==0.13.363
 
 # Runtime requirements declared by the Home Assistant conversation and camera
 # components exercised by these tests.
-gazetteer-matcher==1.0.0
+gazetteer-matcher==1.1.0
 hassil==3.12.0
-home-assistant-intents==2026.8.25
+home-assistant-intents==2026.8.28
 PyTurboJPEG==1.8.3
-
-# Imported directly by Codex Assist for AI Task schema conversion.
-voluptuous-openapi==0.4.1

--- a/requirements_test_ha_previous.txt
+++ b/requirements_test_ha_previous.txt
@@ -1,0 +1,13 @@
+# Previous Home Assistant contract, before the Probatio transition (Python 3.14+).
+homeassistant==2026.8.3
+pytest-homeassistant-custom-component==0.13.357
+
+# Runtime requirements declared by the Home Assistant conversation and camera
+# components exercised by these tests.
+gazetteer-matcher==1.0.0
+hassil==3.12.0
+home-assistant-intents==2026.8.25
+PyTurboJPEG==1.8.3
+
+# Converter used by this Home Assistant version.
+voluptuous-openapi==0.4.1

--- a/tests/ha_fakes.py
+++ b/tests/ha_fakes.py
@@ -244,6 +244,7 @@ def install_homeassistant_fakes(monkeypatch):
     voluptuous_openapi.convert = lambda schema, custom_serializer=None: getattr(
         schema, "schema", schema
     )
+    llm.convert = voluptuous_openapi.convert
     vol.Invalid = Invalid
     vol.Any = Any  # type: ignore[attr-defined]
     vol.All = All  # type: ignore[attr-defined]

--- a/tests/test_ai_task_behavior.py
+++ b/tests/test_ai_task_behavior.py
@@ -188,7 +188,7 @@ def test_structured_output_format_preserves_optional_semantics_in_nested_schema(
     }
     monkeypatch.setattr(
         ai_task_module,
-        "convert",
+        "to_openapi",
         lambda structure, custom_serializer: converted_schema,
     )
     task = type("Task", (), {"name": "Home State", "structure": object()})()

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -1,0 +1,28 @@
+"""The converter must match HA even when both schema libraries are installed."""
+
+import runpy
+import sys
+from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
+
+from tests.ha_fakes import install_homeassistant_fakes
+
+
+@pytest.mark.parametrize("converter_name", ["convert", "to_openapi"])
+def test_converter_follows_home_assistant_not_installed_packages(monkeypatch, converter_name):
+    install_homeassistant_fakes(monkeypatch)
+    llm = sys.modules["homeassistant.helpers.llm"]
+    monkeypatch.delattr(llm, "convert")
+    converter = Mock(return_value={"type": "object"})
+    monkeypatch.setattr(llm, converter_name, converter, raising=False)
+    for package, function in [("probatio", "to_openapi"), ("voluptuous_openapi", "convert")]:
+        module = ModuleType(package)
+        setattr(module, function, Mock(side_effect=AssertionError("Wrong converter selected")))
+        monkeypatch.setitem(sys.modules, package, module)
+
+    compat = runpy.run_path("custom_components/codex_assist/schema_compat.py")
+    schema, serializer = object(), object()
+    assert compat["to_openapi"](schema, custom_serializer=serializer) == {"type": "object"}
+    converter.assert_called_once_with(schema, custom_serializer=serializer)

--- a/tests_ha/test_smoke.py
+++ b/tests_ha/test_smoke.py
@@ -102,6 +102,11 @@ async def test_conversation_turn_streams_codex_reply(
     await _setup_entry(hass)
 
     async def fake_stream_turn(self: CodexClient, **kwargs: object):
+        tools = kwargs["tools"]
+        assert isinstance(tools, list)
+        function_tools = [tool for tool in tools if tool.get("type") == "function"]
+        assert function_tools
+        assert all(isinstance(tool.get("parameters"), dict) for tool in function_tools)
         yield CodexTextDelta("The porch light is on.")
 
     monkeypatch.setattr(CodexClient, "stream_turn", fake_stream_turn)

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,6 @@ version = "0.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },
-    { name = "voluptuous-openapi" },
 ]
 
 [package.optional-dependencies]
@@ -63,7 +62,6 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
-    { name = "voluptuous-openapi", specifier = ">=0.3,<0.5" },
 ]
 provides-extras = ["dev"]
 
@@ -191,25 +189,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
     { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
     { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
-]
-
-[[package]]
-name = "voluptuous"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/92/f4/0738e6849858deae22218be3bbb8207ba83a96e9d0ec7e8e8cd67b30e5ca/voluptuous-0.16.0.tar.gz", hash = "sha256:006535e22fed944aec17bef6e8725472476194743c87bd233e912eb463f8ff05", size = 54238, upload-time = "2025-12-18T23:18:46.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl", hash = "sha256:ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4", size = 31931, upload-time = "2025-12-18T23:18:44.694Z" },
-]
-
-[[package]]
-name = "voluptuous-openapi"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "voluptuous" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/60/a5/517c143607fd82cfc8842fcdccf5cf2c07cdd96528c936bde196e05dece3/voluptuous_openapi-0.4.1.tar.gz", hash = "sha256:745d0d60940a851d9a90c87eebf659c57072c9ef305c0f6f04f4fd7c063dc0ac", size = 21432, upload-time = "2026-06-26T13:31:35.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/bb/64db054ad3852e3b63841a570942d3ce29e6b44979d5ac4be806973a2338/voluptuous_openapi-0.4.1-py3-none-any.whl", hash = "sha256:b30abc527c622cd62dba1269a05099e6b6170678c2838908d347fa85ab0cdb44", size = 12824, upload-time = "2026-06-26T13:31:35.126Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "ha-codex-assist"
-version = "0.4.3"
+version = "0.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Home Assistant 2026.9 replaced voluptuous-openapi with Probatio. Passing
Probatio's custom serializer through the legacy converter returned its distinct
UNSUPPORTED sentinel as a schema, causing every Assist tool conversion to fail.

Assist tool handling then fails with:

`TypeError: '_Unsupported' object is not iterable`

Use `to_openapi` for compatibility to convert from Probatio schemas for
conversation tools and structured AI Tasks. Prefer `probatio.to_openapi` where HA provides it
and retain the legacy converter fallback for the supported HA 2026.6
minimum. Remove voluptuous-openapi as a direct project dependency so each
contract environment supplies its native converter.

Advances the current Home Assistant contract lane to 2026.9.0.

## Verification

- [x] `uv run ruff check .`
- [x] `uv run pytest -q` — 135 passed
- [x] Home Assistant 2026.9.0 contract suite — 13 passed
- [x] Home Assistant 2026.6.0 minimum contract suite — 13 passed
- [x] Documentation updated when behavior, setup, compatibility, or safety changed
- [x] No tokens, device codes, cookies, secrets, private URLs, or unredacted logs/screenshots included

The same implementation was installed from fork prerelease
`v0.4.4-rc.1` on Home Assistant 2026.9 and tested with:

- voice and text conversations;
- an exposed-light action;
- a weather request;
- a structured AI Task; and
- a post-restart live core-log follow, with no errors or warnings emitted
  during the light and weather requests.

## Compatibility and safety

Home Assistant 2026.9 uses Probatio conversion, while Home Assistant
2026.6 retains the legacy converter supplied by that Home Assistant
environment. Both paths are covered by isolated real-Home-Assistant
contract tests.

The compatibility boundary is applied to both Assist function-tool
parameters and structured AI Task output schemas. Exposed-entity routing,
authentication, model selection, and tool-execution safety behavior are
unchanged.
